### PR TITLE
F Legg flere feilmeldinger til enum Feilmelding under person

### DIFF
--- a/person-dtos/main/no/nav/tiltakspenger/libs/person/Feilmelding.kt
+++ b/person-dtos/main/no/nav/tiltakspenger/libs/person/Feilmelding.kt
@@ -2,4 +2,14 @@ package no.nav.tiltakspenger.libs.person
 
 enum class Feilmelding(val message: String) {
     PersonIkkeFunnet("Fant ikke person i PDL"),
+    NavnIkkeFunnet("Fant ikke navn i PDL"),
+    NavnKunneIkkeAvklares("Navn kunne ikke avklares fra PDL respons"),
+    FødselKunneIkkeAvklares("Fødsel kunne ikke avklares fra PDL respons"),
+    AdressebeskyttelseKunneIkkeAvklares("Adressebeskyttelse kunne ikke avklares fra PDL respons"),
+    NetworkError("PDL er nede!!"),
+    UkjentFeil("Uhåndtert feil oppsto ved å hente person fra PDL"),
+    ResponsManglerPerson("Person finnes ikke i PDL"),
+    SerializationException("Feil ved serializering av PDL data"),
+    GraderingKunneIkkeAvklares("Kunne ikke avklare gradering"),
+    AzureAuthFailureException("Kunne ikke autentisere mot Azure"),
 }


### PR DESCRIPTION
## Beskrivelse
Det er flere feilmeldinger som skal håndteres i tiltakspenger-person ved henting av data fra PDL som ikke er tilgjengelig i tiltakspenger-libs, så har jeg utvidet den eksisterende enum <Feilmeldinger>

Jeg har utvidet <Feilmeldinger> enum med de feilene som er allerede lagt til PDLClientError i tiltakspenger-person


