### PR TITLE
Småfikser

### DIFF
--- a/periodisering/main/no/nav/tiltakspenger/libs/periodisering/Periodisering.kt
+++ b/periodisering/main/no/nav/tiltakspenger/libs/periodisering/Periodisering.kt
@@ -33,6 +33,7 @@ data class Periodisering<T> private constructor(
             )
         }
 
+        // Tryner hvis det ikke er minst ett element i lista
         fun <T> List<Periodisering<T>>.reduser(sammensattVerdi: (T, T) -> T): Periodisering<T> {
             return this.reduce { total: Periodisering<T>, next: Periodisering<T> ->
                 total.kombiner(next, sammensattVerdi).slåSammenTilstøtendePerioder()

--- a/periodisering/main/no/nav/tiltakspenger/libs/periodisering/Periodisering.kt
+++ b/periodisering/main/no/nav/tiltakspenger/libs/periodisering/Periodisering.kt
@@ -9,15 +9,15 @@ data class Periodisering<T>(
 ) {
     init {
         require(
-            perioderMedVerdi.sortedBy { it.periode.fra }.zipWithNext()
-                .all { it.second.periode.fra == it.first.periode.til.plusDays(1) },
-        ) { "Ugyldig periodisering, hull tillates ikke" }
+            perioderMedVerdi.sortedBy { it.periode.fraOgMed }.zipWithNext()
+                .all { it.second.periode.fraOgMed == it.first.periode.tilOgMed.plusDays(1) },
+        ) { "Ugyldig periodisering, for alle perioderMedVerdi gjelder at periode n+1 må starte dagen etter periode n slutter" }
     }
 
     val totalePeriode
         get() = Periode(
-            perioderMedVerdi.minOf { it.periode.fra },
-            perioderMedVerdi.maxOf { it.periode.til },
+            perioderMedVerdi.minOf { it.periode.fraOgMed },
+            perioderMedVerdi.maxOf { it.periode.tilOgMed },
         )
 
     companion object {
@@ -78,7 +78,7 @@ data class Periodisering<T>(
             .slåSammenTilstøtendePerioder()
             .let { Periodisering(it) }
 
-    fun perioder(): List<PeriodeMedVerdi<T>> = perioderMedVerdi.sortedBy { it.periode.fra }
+    fun perioder(): List<PeriodeMedVerdi<T>> = perioderMedVerdi.sortedBy { it.periode.fraOgMed }
 
     // Private hjelpemetoder:
 
@@ -128,7 +128,7 @@ data class Periodisering<T>(
 
     override fun toString(): String {
         return "Periodisering(totalePeriode=$totalePeriode, perioderMedVerdi=${
-            perioderMedVerdi.sortedBy { it.periode.fra }.map { "\n" + it.toString() }
+            perioderMedVerdi.sortedBy { it.periode.fraOgMed }.map { "\n" + it.toString() }
         })"
     }
 
@@ -137,7 +137,7 @@ data class Periodisering<T>(
         val nyePerioder = nyeTotalePeriode.trekkFra(listOf(totalePeriode))
         return this.copy(
             perioderMedVerdi = (this.perioderMedVerdi + nyePerioder.map { PeriodeMedVerdi(verdi, it) })
-                .sortedBy { it.periode.fra },
+                .sortedBy { it.periode.fraOgMed },
         )
     }
 
@@ -150,7 +150,7 @@ data class Periodisering<T>(
 
         other as Periodisering<*>
 
-        return perioderMedVerdi.sortedBy { it.periode.fra } == other.perioderMedVerdi.sortedBy { it.periode.fra }
+        return perioderMedVerdi.sortedBy { it.periode.fraOgMed } == other.perioderMedVerdi.sortedBy { it.periode.fraOgMed }
     }
 
     override fun hashCode(): Int {

--- a/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodeTest.kt
+++ b/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodeTest.kt
@@ -110,10 +110,10 @@ class PeriodeTest {
         val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo))
         assertEquals(2, perioder.size)
-        assertEquals(3.mai(2022), perioder[0].fra)
-        assertEquals(5.mai(2022), perioder[0].til)
-        assertEquals(13.mai(2022), perioder[1].fra)
-        assertEquals(15.mai(2022), perioder[1].til)
+        assertEquals(3.mai(2022), perioder[0].fraOgMed)
+        assertEquals(5.mai(2022), perioder[0].tilOgMed)
+        assertEquals(13.mai(2022), perioder[1].fraOgMed)
+        assertEquals(15.mai(2022), perioder[1].tilOgMed)
     }
 
     @Test
@@ -122,8 +122,8 @@ class PeriodeTest {
         val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 18.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo))
         assertEquals(1, perioder.size)
-        assertEquals(3.mai(2022), perioder[0].fra)
-        assertEquals(5.mai(2022), perioder[0].til)
+        assertEquals(3.mai(2022), perioder[0].fraOgMed)
+        assertEquals(5.mai(2022), perioder[0].tilOgMed)
     }
 
     @Test
@@ -133,12 +133,12 @@ class PeriodeTest {
         val periodeTre = Periode(fraOgMed = 10.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo, periodeTre))
         assertEquals(3, perioder.size)
-        assertEquals(3.mai(2022), perioder[0].fra)
-        assertEquals(5.mai(2022), perioder[0].til)
-        assertEquals(9.mai(2022), perioder[1].fra)
-        assertEquals(9.mai(2022), perioder[1].til)
-        assertEquals(13.mai(2022), perioder[2].fra)
-        assertEquals(15.mai(2022), perioder[2].til)
+        assertEquals(3.mai(2022), perioder[0].fraOgMed)
+        assertEquals(5.mai(2022), perioder[0].tilOgMed)
+        assertEquals(9.mai(2022), perioder[1].fraOgMed)
+        assertEquals(9.mai(2022), perioder[1].tilOgMed)
+        assertEquals(13.mai(2022), perioder[2].fraOgMed)
+        assertEquals(15.mai(2022), perioder[2].tilOgMed)
     }
 
     @Test
@@ -148,10 +148,10 @@ class PeriodeTest {
         val periodeTre = Periode(fraOgMed = 10.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo, periodeTre))
         assertEquals(2, perioder.size)
-        assertEquals(3.mai(2022), perioder[0].fra)
-        assertEquals(5.mai(2022), perioder[0].til)
-        assertEquals(13.mai(2022), perioder[1].fra)
-        assertEquals(15.mai(2022), perioder[1].til)
+        assertEquals(3.mai(2022), perioder[0].fraOgMed)
+        assertEquals(5.mai(2022), perioder[0].tilOgMed)
+        assertEquals(13.mai(2022), perioder[1].fraOgMed)
+        assertEquals(15.mai(2022), perioder[1].tilOgMed)
     }
 
     @Test

--- a/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodeTest.kt
+++ b/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodeTest.kt
@@ -12,9 +12,9 @@ import java.time.LocalDate
 
 class PeriodeTest {
 
-    private val periode1 = Periode(fra = 13.mai(2022), til = 18.mai(2022))
-    private val periode2 = Periode(fra = 17.mai(2022), til = 21.mai(2022))
-    private val periode3 = Periode(fra = 19.mai(2022), til = 20.mai(2022))
+    private val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 18.mai(2022))
+    private val periode2 = Periode(fraOgMed = 17.mai(2022), tilOgMed = 21.mai(2022))
+    private val periode3 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 20.mai(2022))
 
     @Test
     fun inneholderHele() {
@@ -32,7 +32,7 @@ class PeriodeTest {
 
     @Test
     fun intersect() {
-        val fellesperiode = Periode(fra = 17.mai(2022), til = 18.mai(2022))
+        val fellesperiode = Periode(fraOgMed = 17.mai(2022), tilOgMed = 18.mai(2022))
         assertEquals(periode1, periode1.overlappendePeriode(periode1))
         assertEquals(fellesperiode, periode1.overlappendePeriode(periode2))
         assertEquals(fellesperiode, periode2.overlappendePeriode(periode1))
@@ -41,7 +41,7 @@ class PeriodeTest {
 
     @Test
     fun overlapperIkkeMed() {
-        val periodeSomIkkeOverlapper = Periode(fra = 13.mai(2022), til = 16.mai(2022))
+        val periodeSomIkkeOverlapper = Periode(fraOgMed = 13.mai(2022), tilOgMed = 16.mai(2022))
         assertEquals(periodeSomIkkeOverlapper, periode1.ikkeOverlappendePeriode(periode2).first())
     }
 
@@ -52,18 +52,18 @@ class PeriodeTest {
 
     @Test
     fun `to overlappende perioder`() {
-        val periodeEn = Periode(fra = 13.mai(2022), til = 16.mai(2022))
-        val periodeTo = Periode(fra = 13.mai(2022), til = 15.mai(2022))
-        val fasit = Periode(fra = 16.mai(2022), til = 16.mai(2022))
+        val periodeEn = Periode(fraOgMed = 13.mai(2022), tilOgMed = 16.mai(2022))
+        val periodeTo = Periode(fraOgMed = 13.mai(2022), tilOgMed = 15.mai(2022))
+        val fasit = Periode(fraOgMed = 16.mai(2022), tilOgMed = 16.mai(2022))
         assertEquals(fasit, periodeEn.ikkeOverlappendePeriode(periodeTo).first())
         assertEquals(1, periodeEn.ikkeOverlappendePeriode(periodeTo).size)
     }
 
     @Test
     fun `ikkeOverlappendePerioder fjerner overlapp mellom flere perioder --fengsel---kvp---`() {
-        val periodeEn = Periode(fra = 1.mai(2022), til = 15.mai(2022))
-        val fengselPeriode = Periode(fra = 5.mai(2022), til = 6.mai(2022))
-        val kvpPeriode = Periode(fra = 11.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 1.mai(2022), tilOgMed = 15.mai(2022))
+        val fengselPeriode = Periode(fraOgMed = 5.mai(2022), tilOgMed = 6.mai(2022))
+        val kvpPeriode = Periode(fraOgMed = 11.mai(2022), tilOgMed = 12.mai(2022))
 
         val result = periodeEn.ikkeOverlappendePerioder(
             listOf(
@@ -74,9 +74,9 @@ class PeriodeTest {
         assertEquals(3, result.size)
         assertEquals(
             listOf(
-                Periode(fra = 1.mai(2022), til = 4.mai(2022)),
-                Periode(fra = 7.mai(2022), til = 10.mai(2022)),
-                Periode(fra = 13.mai(2022), til = 15.mai(2022)),
+                Periode(fraOgMed = 1.mai(2022), tilOgMed = 4.mai(2022)),
+                Periode(fraOgMed = 7.mai(2022), tilOgMed = 10.mai(2022)),
+                Periode(fraOgMed = 13.mai(2022), tilOgMed = 15.mai(2022)),
             ),
             result,
         )
@@ -84,9 +84,9 @@ class PeriodeTest {
 
     @Test
     fun `ikkeOverlappendePerioder fjerner overlapp mellom flere perioder --fengselOgKvp---`() {
-        val periodeEn = Periode(fra = 1.mai(2022), til = 15.mai(2022))
-        val fengselPeriode = Periode(fra = 5.mai(2022), til = 11.mai(2022))
-        val kvpPeriode = Periode(fra = 10.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 1.mai(2022), tilOgMed = 15.mai(2022))
+        val fengselPeriode = Periode(fraOgMed = 5.mai(2022), tilOgMed = 11.mai(2022))
+        val kvpPeriode = Periode(fraOgMed = 10.mai(2022), tilOgMed = 12.mai(2022))
 
         val result = periodeEn.ikkeOverlappendePerioder(
             listOf(
@@ -97,8 +97,8 @@ class PeriodeTest {
         assertEquals(2, result.size)
         assertEquals(
             listOf(
-                Periode(fra = 1.mai(2022), til = 4.mai(2022)),
-                Periode(fra = 13.mai(2022), til = 15.mai(2022)),
+                Periode(fraOgMed = 1.mai(2022), tilOgMed = 4.mai(2022)),
+                Periode(fraOgMed = 13.mai(2022), tilOgMed = 15.mai(2022)),
             ),
             result,
         )
@@ -106,8 +106,8 @@ class PeriodeTest {
 
     @Test
     fun `man kan trekke en periode fra en annen periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 6.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo))
         assertEquals(2, perioder.size)
         assertEquals(3.mai(2022), perioder[0].fra)
@@ -118,8 +118,8 @@ class PeriodeTest {
 
     @Test
     fun `man kan trekke en periode fra en annen ikke-overlappende periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 6.mai(2022), til = 18.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 18.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo))
         assertEquals(1, perioder.size)
         assertEquals(3.mai(2022), perioder[0].fra)
@@ -128,9 +128,9 @@ class PeriodeTest {
 
     @Test
     fun `man kan trekke flere perioder fra en annen periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 6.mai(2022), til = 8.mai(2022))
-        val periodeTre = Periode(fra = 10.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 8.mai(2022))
+        val periodeTre = Periode(fraOgMed = 10.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo, periodeTre))
         assertEquals(3, perioder.size)
         assertEquals(3.mai(2022), perioder[0].fra)
@@ -143,9 +143,9 @@ class PeriodeTest {
 
     @Test
     fun `man kan trekke flere connected perioder fra en annen periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 6.mai(2022), til = 9.mai(2022))
-        val periodeTre = Periode(fra = 10.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 9.mai(2022))
+        val periodeTre = Periode(fraOgMed = 10.mai(2022), tilOgMed = 12.mai(2022))
         val perioder = periodeEn.trekkFra(listOf(periodeTo, periodeTre))
         assertEquals(2, perioder.size)
         assertEquals(3.mai(2022), perioder[0].fra)
@@ -156,9 +156,9 @@ class PeriodeTest {
 
     @Test
     fun `man kan ikke trekke flere overlappende perioder fra en annen periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 6.mai(2022), til = 10.mai(2022))
-        val periodeTre = Periode(fra = 9.mai(2022), til = 12.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 6.mai(2022), tilOgMed = 10.mai(2022))
+        val periodeTre = Periode(fraOgMed = 9.mai(2022), tilOgMed = 12.mai(2022))
         Assertions.assertThrows(IllegalArgumentException::class.java) {
             periodeEn.trekkFra(listOf(periodeTo, periodeTre))
         }
@@ -166,59 +166,59 @@ class PeriodeTest {
 
     @Test
     fun `hvis man legger sammen to perioder som overlapper får man en periode`() {
-        val periodeEn = Periode(fra = 3.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 10.mai(2022), til = 20.mai(2022))
-        val periodeTre = Periode(fra = 3.mai(2022), til = 20.mai(2022))
+        val periodeEn = Periode(fraOgMed = 3.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 10.mai(2022), tilOgMed = 20.mai(2022))
+        val periodeTre = Periode(fraOgMed = 3.mai(2022), tilOgMed = 20.mai(2022))
         assertEquals(periodeTre, listOf(periodeEn, periodeTo).leggSammen().first())
     }
 
     @Test
     fun `hvis man legger sammen to tilstøtende perioder får man en periode`() {
-        val periodeEn = Periode(fra = 6.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 1.mai(2022), til = 5.mai(2022))
-        val periodeTre = Periode(fra = 1.mai(2022), til = 15.mai(2022))
+        val periodeEn = Periode(fraOgMed = 6.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 1.mai(2022), tilOgMed = 5.mai(2022))
+        val periodeTre = Periode(fraOgMed = 1.mai(2022), tilOgMed = 15.mai(2022))
         assertEquals(1, listOf(periodeEn, periodeTo).leggSammen().size)
         assertEquals(periodeTre, listOf(periodeEn, periodeTo).leggSammen().first())
     }
 
     @Test
     fun `hvis man legger sammen to tilstøtende perioder og en tredje separat periode får man to perioder`() {
-        val periodeEn = Periode(fra = 6.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 1.mai(2022), til = 5.mai(2022))
-        val periodeFasitEn = Periode(fra = 1.mai(2022), til = 15.mai(2022))
-        val periodeTre = Periode(fra = 18.mai(2022), til = 20.mai(2022))
-        val periodeFasitTo = Periode(fra = 18.mai(2022), til = 20.mai(2022))
+        val periodeEn = Periode(fraOgMed = 6.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 1.mai(2022), tilOgMed = 5.mai(2022))
+        val periodeFasitEn = Periode(fraOgMed = 1.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTre = Periode(fraOgMed = 18.mai(2022), tilOgMed = 20.mai(2022))
+        val periodeFasitTo = Periode(fraOgMed = 18.mai(2022), tilOgMed = 20.mai(2022))
         assertEquals(periodeFasitEn, listOf(periodeEn, periodeTo, periodeTre).leggSammen().first())
         assertEquals(periodeFasitTo, listOf(periodeEn, periodeTo, periodeTre).leggSammen().last())
     }
 
     @Test
     fun `to overlappende perioder gir overlapp`() {
-        val periodeEn = Periode(fra = 6.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 1.mai(2022), til = 7.mai(2022))
+        val periodeEn = Periode(fraOgMed = 6.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 1.mai(2022), tilOgMed = 7.mai(2022))
         assertEquals(true, listOf(periodeEn, periodeTo).inneholderOverlapp())
     }
 
     @Test
     fun `to ikke-overlappende perioder gir ikke overlapp`() {
-        val periodeEn = Periode(fra = 8.mai(2022), til = 15.mai(2022))
-        val periodeTo = Periode(fra = 1.mai(2022), til = 7.mai(2022))
+        val periodeEn = Periode(fraOgMed = 8.mai(2022), tilOgMed = 15.mai(2022))
+        val periodeTo = Periode(fraOgMed = 1.mai(2022), tilOgMed = 7.mai(2022))
         assertEquals(false, listOf(periodeEn, periodeTo).inneholderOverlapp())
     }
 
     @Test
     fun `tre ikke-overlappende perioder der den tredje er mellom de to første gir ikke overlapp`() {
-        val periodeEn = Periode(fra = 1.mai(2022), til = 10.mai(2022))
-        val periodeTo = Periode(fra = 20.mai(2022), til = 25.mai(2022))
-        val periodeTre = Periode(fra = 11.mai(2022), til = 19.mai(2022))
+        val periodeEn = Periode(fraOgMed = 1.mai(2022), tilOgMed = 10.mai(2022))
+        val periodeTo = Periode(fraOgMed = 20.mai(2022), tilOgMed = 25.mai(2022))
+        val periodeTre = Periode(fraOgMed = 11.mai(2022), tilOgMed = 19.mai(2022))
         assertEquals(false, listOf(periodeEn, periodeTo, periodeTre).inneholderOverlapp())
     }
 
     @Test
     fun `tre ikke-overlappende perioder der den tredje med den andre gir overlapp`() {
-        val periodeEn = Periode(fra = 1.mai(2022), til = 10.mai(2022))
-        val periodeTo = Periode(fra = 20.mai(2022), til = 25.mai(2022))
-        val periodeTre = Periode(fra = 11.mai(2022), til = 20.mai(2022))
+        val periodeEn = Periode(fraOgMed = 1.mai(2022), tilOgMed = 10.mai(2022))
+        val periodeTo = Periode(fraOgMed = 20.mai(2022), tilOgMed = 25.mai(2022))
+        val periodeTre = Periode(fraOgMed = 11.mai(2022), tilOgMed = 20.mai(2022))
         assertEquals(true, listOf(periodeEn, periodeTo, periodeTre).inneholderOverlapp())
     }
 
@@ -232,22 +232,22 @@ class PeriodeTest {
 
     @Test
     fun `perioder som er adjacent skal legges sammen og bli en periode`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 18.mai(2022))
-        val periode2 = Periode(fra = 19.mai(2022), til = 21.mai(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 27.mai(2022))
-        val periode4 = Periode(fra = 27.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 18.mai(2022))
+        val periode2 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 21.mai(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 27.mai(2022))
+        val periode4 = Periode(fraOgMed = 27.mai(2022), tilOgMed = 30.mai(2022))
         val nyePerioder = listOf(periode1, periode2).leggSammenMed(listOf(periode3, periode4))
 
         nyePerioder.size shouldBe 1
-        nyePerioder.first() shouldBe Periode(fra = 13.mai(2022), til = 30.mai(2022))
+        nyePerioder.first() shouldBe Periode(fraOgMed = 13.mai(2022), tilOgMed = 30.mai(2022))
     }
 
     @Test
     fun `perioder som er adjacent skal ikke ha noen overlappende periode`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 18.mai(2022))
-        val periode2 = Periode(fra = 19.mai(2022), til = 21.mai(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 27.mai(2022))
-        val periode4 = Periode(fra = 27.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 18.mai(2022))
+        val periode2 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 21.mai(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 27.mai(2022))
+        val periode4 = Periode(fraOgMed = 27.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = listOf(periode1, periode2).overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 0
@@ -255,34 +255,34 @@ class PeriodeTest {
 
     @Test
     fun `perioder som er delvis overlappende skal ha en overlappende periode`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 18.mai(2022))
-        val periode2 = Periode(fra = 19.mai(2022), til = 25.mai(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 23.mai(2022))
-        val periode4 = Periode(fra = 24.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 18.mai(2022))
+        val periode2 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 25.mai(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 23.mai(2022))
+        val periode4 = Periode(fraOgMed = 24.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = listOf(periode1, periode2).overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 1
-        overlappendePerioder.first() shouldBe Periode(fra = 22.mai(2022), til = 25.mai(2022))
+        overlappendePerioder.first() shouldBe Periode(fraOgMed = 22.mai(2022), tilOgMed = 25.mai(2022))
     }
 
     @Test
     fun `perioder som er fullstendig overlappende skal ha en overlappende periode som er lik den minste perioden`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 25.mai(2022))
-        val periode2 = Periode(fra = 19.mai(2022), til = 1.juni(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 23.mai(2022))
-        val periode4 = Periode(fra = 24.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 25.mai(2022))
+        val periode2 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 1.juni(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 23.mai(2022))
+        val periode4 = Periode(fraOgMed = 24.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = listOf(periode1, periode2).overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 1
-        overlappendePerioder.first() shouldBe Periode(fra = 22.mai(2022), til = 30.mai(2022))
+        overlappendePerioder.first() shouldBe Periode(fraOgMed = 22.mai(2022), tilOgMed = 30.mai(2022))
     }
 
     @Test
     fun `overlappende perioder skal fungere uansett hvilken liste som er subjekt og objekt`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 25.mai(2022))
-        val periode2 = Periode(fra = 19.mai(2022), til = 1.juni(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 23.mai(2022))
-        val periode4 = Periode(fra = 24.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 25.mai(2022))
+        val periode2 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 1.juni(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 23.mai(2022))
+        val periode4 = Periode(fraOgMed = 24.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = listOf(periode1, periode2).overlappendePerioder(listOf(periode3, periode4))
         val overlappendePerioder2 = listOf(periode3, periode4).overlappendePerioder(listOf(periode1, periode2))
 
@@ -293,9 +293,9 @@ class PeriodeTest {
 
     @Test
     fun `perioder som er adjacent med periode skal ikke ha noen overlappende periode`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 21.mai(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 27.mai(2022))
-        val periode4 = Periode(fra = 27.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 21.mai(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 27.mai(2022))
+        val periode4 = Periode(fraOgMed = 27.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = periode1.overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 0
@@ -303,109 +303,116 @@ class PeriodeTest {
 
     @Test
     fun `perioder som er delvis overlappende med periode skal ha en overlappende periode`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 25.mai(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 23.mai(2022))
-        val periode4 = Periode(fra = 24.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 25.mai(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 23.mai(2022))
+        val periode4 = Periode(fraOgMed = 24.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = periode1.overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 1
-        overlappendePerioder.first() shouldBe Periode(fra = 22.mai(2022), til = 25.mai(2022))
+        overlappendePerioder.first() shouldBe Periode(fraOgMed = 22.mai(2022), tilOgMed = 25.mai(2022))
     }
 
     @Test
     fun `perioder som er fullstendig overlappende med periode skal ha en overlappende periode som er lik den minste perioden`() {
-        val periode1 = Periode(fra = 13.mai(2022), til = 1.juni(2022))
-        val periode3 = Periode(fra = 22.mai(2022), til = 23.mai(2022))
-        val periode4 = Periode(fra = 24.mai(2022), til = 30.mai(2022))
+        val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 1.juni(2022))
+        val periode3 = Periode(fraOgMed = 22.mai(2022), tilOgMed = 23.mai(2022))
+        val periode4 = Periode(fraOgMed = 24.mai(2022), tilOgMed = 30.mai(2022))
         val overlappendePerioder = periode1.overlappendePerioder(listOf(periode3, periode4))
 
         overlappendePerioder.size shouldBe 1
-        overlappendePerioder.first() shouldBe Periode(fra = 22.mai(2022), til = 30.mai(2022))
+        overlappendePerioder.first() shouldBe Periode(fraOgMed = 22.mai(2022), tilOgMed = 30.mai(2022))
     }
 
     @Test
     fun `når man kaller på kompletter-funksjonen med perioder som overlapper skal det kastes en feil'`() {
-        val periodeSomSkalKompletteres = Periode(fra = 1.januar(2022), til = 31.januar(2022))
-        val subPeriode1 = Periode(fra = 15.januar(2022), til = 16.januar(2022))
-        val subPeriode2 = Periode(fra = 16.januar(2022), til = 17.januar(2022))
-        shouldThrow<IllegalArgumentException> { periodeSomSkalKompletteres.kompletter(listOf(subPeriode1, subPeriode2)) }
+        val periodeSomSkalKompletteres = Periode(fraOgMed = 1.januar(2022), tilOgMed = 31.januar(2022))
+        val subPeriode1 = Periode(fraOgMed = 15.januar(2022), tilOgMed = 16.januar(2022))
+        val subPeriode2 = Periode(fraOgMed = 16.januar(2022), tilOgMed = 17.januar(2022))
+        shouldThrow<IllegalArgumentException> {
+            periodeSomSkalKompletteres.kompletter(
+                listOf(
+                    subPeriode1,
+                    subPeriode2,
+                ),
+            )
+        }
     }
 
     @Test
     fun `når man kaller på kompletter-funksjonen med perioder som går utenfor hovedperioden skal det kastes en feil'`() {
-        val periodeSomSkalKompletteres = Periode(fra = 1.januar(2022), til = 31.januar(2022))
-        val subPeriode1 = Periode(fra = 31.januar(2022), til = 1.februar(2022))
+        val periodeSomSkalKompletteres = Periode(fraOgMed = 1.januar(2022), tilOgMed = 31.januar(2022))
+        val subPeriode1 = Periode(fraOgMed = 31.januar(2022), tilOgMed = 1.februar(2022))
         shouldThrow<IllegalArgumentException> { periodeSomSkalKompletteres.kompletter(listOf(subPeriode1)) }
     }
 
     @Test
     fun `når man kaller på kompletter-funksjonen på en periode skal man få en liste av sub-perioder som, sammen med de periodene man har oppgitt, dekker hele basis-perioden`() {
-        val periodeSomSkalKompletteres = Periode(fra = 1.januar(2022), til = 31.januar(2022))
-        val subPeriode1 = Periode(fra = 1.januar(2022), til = 1.januar(2022))
-        val subPeriode2 = Periode(fra = 20.januar(2022), til = 22.januar(2022))
-        val subPeriode3 = Periode(fra = 15.januar(2022), til = 16.januar(2022))
+        val periodeSomSkalKompletteres = Periode(fraOgMed = 1.januar(2022), tilOgMed = 31.januar(2022))
+        val subPeriode1 = Periode(fraOgMed = 1.januar(2022), tilOgMed = 1.januar(2022))
+        val subPeriode2 = Periode(fraOgMed = 20.januar(2022), tilOgMed = 22.januar(2022))
+        val subPeriode3 = Periode(fraOgMed = 15.januar(2022), tilOgMed = 16.januar(2022))
         val allePerioder = periodeSomSkalKompletteres.kompletter(listOf(subPeriode1, subPeriode2, subPeriode3))
         allePerioder shouldBe listOf(
-            Periode(fra = 1.januar(2022), til = 1.januar(2022)),
-            Periode(fra = 2.januar(2022), til = 14.januar(2022)),
-            Periode(fra = 15.januar(2022), til = 16.januar(2022)),
-            Periode(fra = 17.januar(2022), til = 19.januar(2022)),
-            Periode(fra = 20.januar(2022), til = 22.januar(2022)),
-            Periode(fra = 23.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 1.januar(2022)),
+            Periode(fraOgMed = 2.januar(2022), tilOgMed = 14.januar(2022)),
+            Periode(fraOgMed = 15.januar(2022), tilOgMed = 16.januar(2022)),
+            Periode(fraOgMed = 17.januar(2022), tilOgMed = 19.januar(2022)),
+            Periode(fraOgMed = 20.januar(2022), tilOgMed = 22.januar(2022)),
+            Periode(fraOgMed = 23.januar(2022), tilOgMed = 31.januar(2022)),
         )
     }
 
     @Test
     fun `kompletter-funksjonen skal ta høyde for at en av periodene som oppgis slutter på samme dato som hovedperioden`() {
-        val periodeSomSkalKompletteres = Periode(fra = 1.januar(2022), til = 31.januar(2022))
-        val subPeriode = Periode(fra = 31.januar(2022), til = 31.januar(2022))
+        val periodeSomSkalKompletteres = Periode(fraOgMed = 1.januar(2022), tilOgMed = 31.januar(2022))
+        val subPeriode = Periode(fraOgMed = 31.januar(2022), tilOgMed = 31.januar(2022))
         val allePerioder = periodeSomSkalKompletteres.kompletter(listOf(subPeriode))
         allePerioder shouldBe listOf(
-            Periode(fra = 1.januar(2022), til = 30.januar(2022)),
-            Periode(fra = 31.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 30.januar(2022)),
+            Periode(fraOgMed = 31.januar(2022), tilOgMed = 31.januar(2022)),
         )
     }
 
     @Test
     fun `mergeInnIPerioder skal returnere en liste med perioder hvor periode-instansen har blitt merget inn, slik at alle periodene i kombinasjon danner en sammenhengende periode uten overlapp seg imellom`() {
-        val periode = Periode(fra = 15.januar(2022), til = 20.januar(2022))
+        val periode = Periode(fraOgMed = 15.januar(2022), tilOgMed = 20.januar(2022))
         val andrePerioder = listOf(
-            Periode(fra = 1.januar(2022), til = 14.januar(2022)),
-            Periode(fra = 15.januar(2022), til = 17.januar(2022)),
-            Periode(fra = 18.januar(2022), til = 21.januar(2022)),
-            Periode(fra = 22.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 14.januar(2022)),
+            Periode(fraOgMed = 15.januar(2022), tilOgMed = 17.januar(2022)),
+            Periode(fraOgMed = 18.januar(2022), tilOgMed = 21.januar(2022)),
+            Periode(fraOgMed = 22.januar(2022), tilOgMed = 31.januar(2022)),
         )
         val sammenslåttePerioder = periode.mergeInnIPerioder(andrePerioder)
         sammenslåttePerioder shouldBe listOf(
-            Periode(fra = 1.januar(2022), til = 14.januar(2022)),
-            Periode(fra = 15.januar(2022), til = 20.januar(2022)),
-            Periode(fra = 21.januar(2022), til = 21.januar(2022)),
-            Periode(fra = 22.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 14.januar(2022)),
+            Periode(fraOgMed = 15.januar(2022), tilOgMed = 20.januar(2022)),
+            Periode(fraOgMed = 21.januar(2022), tilOgMed = 21.januar(2022)),
+            Periode(fraOgMed = 22.januar(2022), tilOgMed = 31.januar(2022)),
         )
     }
 
     @Test
     fun `mergeInnIPerioder skal ta høyde for at perioden som merges inn allerede er helt dekket av en eksisterende periode`() {
-        val periode = Periode(fra = 15.januar(2022), til = 20.januar(2022))
+        val periode = Periode(fraOgMed = 15.januar(2022), tilOgMed = 20.januar(2022))
         val andrePerioder = listOf(
-            Periode(fra = 1.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 31.januar(2022)),
         )
         val sammenslåttePerioder = periode.mergeInnIPerioder(andrePerioder)
         sammenslåttePerioder shouldBe listOf(
-            Periode(fra = 1.januar(2022), til = 14.januar(2022)),
-            Periode(fra = 15.januar(2022), til = 20.januar(2022)),
-            Periode(fra = 21.januar(2022), til = 31.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 14.januar(2022)),
+            Periode(fraOgMed = 15.januar(2022), tilOgMed = 20.januar(2022)),
+            Periode(fraOgMed = 21.januar(2022), tilOgMed = 31.januar(2022)),
         )
     }
 
     @Test
     fun `mergeInnIPerioder skal kaste en IllegalArgumentException dersom noen av periodene i periode-lista overlapper med hverandre`() {
         val perioder = listOf(
-            Periode(fra = 1.januar(2022), til = 2.januar(2022)),
-            Periode(fra = 2.januar(2022), til = 3.januar(2022)),
+            Periode(fraOgMed = 1.januar(2022), tilOgMed = 2.januar(2022)),
+            Periode(fraOgMed = 2.januar(2022), tilOgMed = 3.januar(2022)),
         )
         shouldThrow<IllegalArgumentException> {
-            val periode = Periode(fra = 1.januar(2022), til = 2.januar(2022))
+            val periode = Periode(fraOgMed = 1.januar(2022), tilOgMed = 2.januar(2022))
             periode.mergeInnIPerioder(perioder)
         }
     }

--- a/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringMedNullableTest.kt
+++ b/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringMedNullableTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test
 
 class PeriodiseringMedNullableTest {
 
-    private val totalePeriode = Periode(fra = 13.mai(2022), til = 21.mai(2022))
-    private val periode1 = Periode(fra = 13.mai(2022), til = 18.mai(2022))
-    private val periode2 = Periode(fra = 17.mai(2022), til = 21.mai(2022))
-    private val periode3 = Periode(fra = 19.mai(2022), til = 20.mai(2022))
+    private val totalePeriode = Periode(fraOgMed = 13.mai(2022), tilOgMed = 21.mai(2022))
+    private val periode1 = Periode(fraOgMed = 13.mai(2022), tilOgMed = 18.mai(2022))
+    private val periode2 = Periode(fraOgMed = 17.mai(2022), tilOgMed = 21.mai(2022))
+    private val periode3 = Periode(fraOgMed = 19.mai(2022), tilOgMed = 20.mai(2022))
 
     @Test
     fun `skal kunne sette null i periodene`() {

--- a/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringTest.kt
+++ b/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringTest.kt
@@ -1,16 +1,63 @@
 package no.nav.tiltakspenger.libs.periodisering
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.equals.shouldBeEqual
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class PeriodiseringTest {
 
-    private val totalePeriode = Periode(fra = 13.mai(2022), til = 21.mai(2022))
-    private val delPeriode = Periode(fra = 18.mai(2022), til = 21.mai(2022))
+    private val totalePeriode = Periode(fraOgMed = 13.mai(2022), tilOgMed = 21.mai(2022))
+    private val delPeriode = Periode(fraOgMed = 18.mai(2022), tilOgMed = 21.mai(2022))
 
     @Test
     fun `skal kunne sette samme verdi som er i perioden fra før`() {
         val periodisering = Periodisering(1, totalePeriode)
         periodisering.setVerdiForDelPeriode(1, delPeriode)
         // Skal ikke feile, noe det gjorde før..
+    }
+
+    @Test
+    fun `skal kunne opprette en tom periodisering`() {
+        Periodisering(emptyList<PeriodeMedVerdi<String>>())
+    }
+
+    @Test
+    fun `skal ikke kunne opprette en periodisering med hull`() {
+        shouldThrow<IllegalArgumentException> {
+            Periodisering(
+                listOf(
+                    PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 20))),
+                    PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 22), LocalDate.of(2023, 1, 24))),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `skal kunne opprette en periodisering med perioder i ikke-kronologisk rekkefølge`() {
+        Periodisering(
+            listOf(
+                PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 22), LocalDate.of(2023, 1, 24))),
+                PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 21))),
+            ),
+        )
+    }
+
+    @Test
+    fun `to periodiseringer med like perioder i ulik rekkefølge skal være like`() {
+        val periodisering1 = Periodisering(
+            listOf(
+                PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 22), LocalDate.of(2023, 1, 24))),
+                PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 21))),
+            ),
+        )
+        val periodisering2 = Periodisering(
+            listOf(
+                PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 21))),
+                PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 22), LocalDate.of(2023, 1, 24))),
+            ),
+        )
+        periodisering1 shouldBeEqual periodisering2
     }
 }

--- a/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringTest.kt
+++ b/periodisering/test/no/nav/tiltakspenger/libs/periodisering/PeriodiseringTest.kt
@@ -60,4 +60,28 @@ class PeriodiseringTest {
         )
         periodisering1 shouldBeEqual periodisering2
     }
+
+    @Test
+    fun `skal ikke kunne opprette en periodisering med duplikate perioder`() {
+        shouldThrow<IllegalArgumentException> {
+            Periodisering(
+                listOf(
+                    PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 20))),
+                    PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 20))),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `skal ikke kunne opprette en periodisering med overlappende perioder`() {
+        shouldThrow<IllegalArgumentException> {
+            Periodisering(
+                listOf(
+                    PeriodeMedVerdi("foo", Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 20))),
+                    PeriodeMedVerdi("bar", Periode(LocalDate.of(2023, 1, 10), LocalDate.of(2023, 1, 30))),
+                ),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Ryddet litt i Periode:
- Flyttet LocalDateDiscreteDomain inn i Periode
- Lagt til en eksplisitt validering i init i Periode, ikke bare basere seg på Range sin
- Bruker properties fraOgMed og tilOgMed i stedet for fra og til

Ryddet litt i Periodisering:
- fjernet funksjonen fraPeriodeListe i companion object, gjort konstruktøren offentlig i stedet
- flyttet valideringen som var i fraPeriodeListe inn i en init-blokk
- erstattet en kommentar med en validering i en require-blokk i reduser-funksjonen
- overrider equals så ikke rekkefølgen på perioderMedVerdi skal ha noe å si
- lagt til noen flere tester