### PR TITLE
legger til saksnummer siden denne skal hentes på forhånd fra saksbeha…

### DIFF
--- a/soknad-dtos/main/no/nav/tiltakspenger/libs/soknad/SøknadDTO.kt
+++ b/soknad-dtos/main/no/nav/tiltakspenger/libs/soknad/SøknadDTO.kt
@@ -24,6 +24,7 @@ data class SøknadDTO(
     val jobbsjansen: PeriodeSpmDTO,
     val trygdOgPensjon: PeriodeSpmDTO,
     val opprettet: LocalDateTime,
+    val saksnummer: String,
 )
 
 data class PersonopplysningerDTO(


### PR DESCRIPTION
…ndling-api pga journalføring

## Beskrivelse
Pga journalføring må saksnummer hentes av søknad-api før søknaden sendes til saksbehandling-api. Dermed bør saksnummeret være en del av requesten for å lagre søknaden i saksbehandling-api. 

## Kommentarer
https://trello.com/c/5ZSIIqvj/1290-for-%C3%A5-kunne-journalf%C3%B8re-s%C3%B8knader-automatisk-m%C3%A5-s%C3%B8knad-api-kunne-hente-saksnummer-fra-saksbehandling-api-f%C3%B8r-s%C3%B8knaden-blir-sendt
