### PR TITLE
legger til journalpostid i request for brukers meldekort

### DIFF
--- a/meldekort-dtos/main/no/nav/tiltakspenger/libs/meldekort/BrukerutfyltMeldekortDTO.kt
+++ b/meldekort-dtos/main/no/nav/tiltakspenger/libs/meldekort/BrukerutfyltMeldekortDTO.kt
@@ -18,6 +18,7 @@ data class BrukerutfyltMeldekortDTO(
     val periode: PeriodeDTO,
     val mottatt: LocalDateTime,
     val dager: Map<LocalDate, Status>,
+    val journalpostId: String,
 ) {
     enum class Status {
         DELTATT,

--- a/meldekort-dtos/test/no/nav/tiltakspenger/libs/meldekort/BrukerutfyltMeldekortDTOTest.kt
+++ b/meldekort-dtos/test/no/nav/tiltakspenger/libs/meldekort/BrukerutfyltMeldekortDTOTest.kt
@@ -25,6 +25,7 @@ class BrukerutfyltMeldekortDTOTest {
         val startDate = LocalDate.of(2024, 1, 1)
         val endDate = LocalDate.of(2024, 1, 14)
         val periode = Periode(startDate, endDate)
+        val journalpostId = "12345"
 
         val dager: Map<LocalDate, BrukerutfyltMeldekortDTO.Status> = buildMap {
             put(periode.fraOgMed, IKKE_RETT_TIL_TILTAKSPENGER)
@@ -53,6 +54,7 @@ class BrukerutfyltMeldekortDTOTest {
             ),
             mottatt = now,
             dager = dager,
+            journalpostId = journalpostId,
         )
 
         val expectedJson = """
@@ -80,7 +82,8 @@ class BrukerutfyltMeldekortDTOTest {
                     "2024-01-12": "IKKE_DELTATT",
                     "2024-01-13": "IKKE_REGISTRERT",
                     "2024-01-14": "IKKE_RETT_TIL_TILTAKSPENGER"
-                  }
+                  },
+                "journalpostId": "$journalpostId"
             }
         """.trimIndent()
 


### PR DESCRIPTION
## Beskrivelse
For at vi skal kunne opprette oppgave med kobling til journalpost for meldekortet må saksbehandling-api få med journalpostid-en sammen med det utfylte meldekortet. 

## Kommentarer
https://trello.com/c/5Del09pN/1302-oppgave-for-mottatt-meldekort
