### PR TITLE
generelt oppsett for kafka

### DIFF
--- a/kafka-test/build.gradle.kts
+++ b/kafka-test/build.gradle.kts
@@ -1,0 +1,11 @@
+val kafkaClientsVersion = "3.9.0"
+val testcontainersVersion = "1.20.4"
+val kotlinxCoroutinesVersion = "1.10.1"
+dependencies {
+    implementation(project(":logging"))
+
+    implementation("org.apache.kafka:kafka-clients:$kafkaClientsVersion")
+    implementation("org.testcontainers:testcontainers:$testcontainersVersion")
+    implementation("org.testcontainers:kafka:$testcontainersVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+}

--- a/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/AsyncUtils.kt
+++ b/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/AsyncUtils.kt
@@ -1,0 +1,36 @@
+package no.nav.tiltakspenger.libs.kafka.test
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.delay
+import java.time.Duration
+import java.time.LocalDateTime
+
+object AsyncUtils {
+    fun eventually(
+        until: Duration = Duration.ofSeconds(3),
+        interval: Duration = Duration.ofMillis(100),
+        func: () -> Unit,
+    ) = no.nav.tiltakspenger.libs.kafka.test.eventually(until, interval, func)
+}
+
+fun eventually(
+    until: Duration = Duration.ofSeconds(3),
+    interval: Duration = Duration.ofMillis(100),
+    func: () -> Unit,
+) = runBlocking {
+    val untilTime = LocalDateTime.now().plusNanos(until.toNanos())
+
+    var throwable: Throwable = IllegalStateException()
+
+    while (LocalDateTime.now().isBefore(untilTime)) {
+        try {
+            func()
+            return@runBlocking
+        } catch (t: Throwable) {
+            throwable = t
+            delay(interval)
+        }
+    }
+
+    throw AssertionError(throwable)
+}

--- a/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/SingletonKafkaProvider.kt
+++ b/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/SingletonKafkaProvider.kt
@@ -1,0 +1,58 @@
+package no.nav.tiltakspenger.libs.kafka.test
+
+import mu.KotlinLogging
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.testcontainers.kafka.KafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+object SingletonKafkaProvider {
+    private val log = KotlinLogging.logger {}
+    private var kafkaContainer: KafkaContainer? = null
+
+    val adminClient: AdminClient by lazy {
+        AdminClient.create(mapOf(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to getHost()))
+    }
+
+    fun start() {
+        if (kafkaContainer != null) return
+
+        log.info { "Starting new Kafka Instance..." }
+
+        kafkaContainer = KafkaContainer(DockerImageName.parse("apache/kafka"))
+            .withEnv("KAFKA_LISTENERS", "PLAINTEXT://:9092,BROKER://:9093,CONTROLLER://:9094") // workaround for https://github.com/testcontainers/testcontainers-java/issues/9506
+        kafkaContainer!!.start()
+
+        setupShutdownHook()
+        log.info { "Kafka setup finished listening on ${kafkaContainer!!.bootstrapServers}." }
+    }
+
+    fun getHost(): String {
+        if (kafkaContainer == null) {
+            start()
+        }
+        return kafkaContainer!!.bootstrapServers
+    }
+
+    private fun setupShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                log.info { "Shutting down Kafka server..." }
+                kafkaContainer?.stop()
+            },
+        )
+    }
+
+    fun cleanup() {
+        val topics = adminClient.listTopics().names().get()
+
+        topics.forEach {
+            try {
+                adminClient.deleteTopics(listOf(it))
+                log.info { "Deleted topic $it" }
+            } catch (e: Exception) {
+                log.warn(e) { "Could not delete topic $it" }
+            }
+        }
+    }
+}

--- a/kafka/build.gradle.kts
+++ b/kafka/build.gradle.kts
@@ -1,0 +1,11 @@
+val kotlinxCoroutinesVersion = "1.10.1"
+val kafkaClientsVersion = "3.9.0"
+dependencies {
+    implementation(project(":logging"))
+
+    api("org.apache.kafka:kafka-clients:$kafkaClientsVersion")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+
+    testImplementation(project(":test-common"))
+    testImplementation(project(":kafka-test"))
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/Consumer.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/Consumer.kt
@@ -1,0 +1,9 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import kotlinx.coroutines.Job
+
+interface Consumer<K, V> {
+    suspend fun consume(key: K, value: V)
+
+    fun run(): Job
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/ConsumerStatus.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/ConsumerStatus.kt
@@ -1,0 +1,30 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import no.nav.tiltakspenger.libs.kafka.config.MAX_POLL_INTERVAL_MS
+import kotlin.math.min
+
+class ConsumerStatus {
+    companion object {
+        const val MAX_DELAY = MAX_POLL_INTERVAL_MS - 60_000L
+    }
+
+    private var _retries: Int = 0
+
+    val retries: Int get() = _retries
+
+    val isFailure: Boolean get() = retries > 0
+
+    val backoffDuration: Long
+        get() {
+            val delay = 500 * retries * retries + 1000L
+            return min(delay, MAX_DELAY)
+        }
+
+    fun success() {
+        _retries = 0
+    }
+
+    fun failure() {
+        _retries++
+    }
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumer.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumer.kt
@@ -1,0 +1,171 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
+import java.time.Duration
+import kotlin.RuntimeException
+
+class ManagedKafkaConsumer<K, V>(
+    private val topic: String,
+    private val config: Map<String, *>,
+    private val consume: suspend (key: K, value: V) -> Unit,
+) {
+    private val log = KotlinLogging.logger {}
+    private val job = Job()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+    private val offsetsToCommit = mutableMapOf<TopicPartition, OffsetAndMetadata>()
+
+    private var running = false
+
+    val status: ConsumerStatus = ConsumerStatus()
+
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                log.info { "Shutting down Kafka consumer" }
+                stop()
+            },
+        )
+    }
+
+    fun run() = scope.launch {
+        log.info { "Starting consumer for topic: $topic" }
+        running = true
+
+        KafkaConsumer<K, V>(config).use { consumer ->
+            subscribe(consumer)
+        }
+    }
+
+    fun start() = run()
+
+    fun stop() {
+        log.info { "Stopping consumer for topic: $topic" }
+        running = false
+    }
+
+    private suspend fun subscribe(consumer: KafkaConsumer<K, V>) {
+        try {
+            consumer.subscribe(listOf(topic), rebalanceListener(consumer))
+
+            while (running) {
+                poll(consumer)
+            }
+        } catch (e: WakeupException) {
+            log.info { "Consumer for $topic is exiting" }
+            stop()
+        } catch (t: Throwable) {
+            log.error(t) { "Something went wrong with consumer for topic $topic" }
+            throw t
+        }
+    }
+
+    private suspend fun poll(consumer: KafkaConsumer<K, V>) {
+        if (status.isFailure) {
+            log.info {
+                "Consumer status for topic $topic is failure, " +
+                    "delaying ${status.backoffDuration}ms before retrying"
+            }
+            delay(status.backoffDuration)
+        }
+
+        try {
+            val records = consumer.poll(Duration.ofMillis(1000))
+
+            seekToEarliestOffsets(records, consumer)
+
+            if (!records.isEmpty) {
+                log.info { "Consumer for $topic polled ${records.count()} records." }
+            }
+
+            records.forEach { record ->
+                process(record)
+
+                val partition = TopicPartition(record.topic(), record.partition())
+                val offset = OffsetAndMetadata(record.offset() + 1)
+
+                offsetsToCommit[partition] = offset
+                status.success()
+            }
+        } catch (t: Throwable) {
+            log.error(t) { t.message }
+            status.failure()
+        } finally {
+            commitOffsets(consumer)
+        }
+    }
+
+    private fun commitOffsets(consumer: KafkaConsumer<K, V>) {
+        if (offsetsToCommit.isNotEmpty()) {
+            offsetsToCommit.forEach { (partition, offset) -> consumer.seek(partition, offset) }
+            consumer.commitSync(offsetsToCommit)
+
+            log.info { "Committed offsets $offsetsToCommit" }
+            offsetsToCommit.clear()
+        }
+    }
+
+    private fun seekToEarliestOffsets(records: ConsumerRecords<K, V>, consumer: KafkaConsumer<K, V>) {
+        val offsetMap = mutableMapOf<TopicPartition, OffsetAndMetadata>()
+
+        records.forEach { record ->
+            val topicPartition = TopicPartition(record.topic(), record.partition())
+            val offsetAndMetadata = OffsetAndMetadata(record.offset())
+
+            val storedOffset = offsetMap[topicPartition]
+
+            if (storedOffset == null || offsetAndMetadata.offset() < storedOffset.offset()) {
+                offsetMap[topicPartition] = offsetAndMetadata
+            }
+        }
+
+        offsetMap.forEach { consumer.seek(it.key, it.value) }
+    }
+
+    private suspend fun process(record: ConsumerRecord<K, V>) {
+        try {
+            consume(record.key(), record.value())
+            log.info {
+                "Consumed record for " +
+                    "topic=${record.topic()} " +
+                    "key=${record.key()} " +
+                    "partition=${record.partition()} " +
+                    "offset=${record.offset()}"
+            }
+        } catch (t: Throwable) {
+            val msg = "Failed to consume record for " +
+                "topic=${record.topic()} " +
+                "key=${record.key()} " +
+                "partition=${record.partition()} " +
+                "offset=${record.offset()}"
+            throw ConsumerProcessingException(msg, t)
+        }
+    }
+
+    class ConsumerProcessingException(
+        msg: String,
+        cause: Throwable?,
+    ) : RuntimeException(msg, cause)
+
+    private fun rebalanceListener(consumer: KafkaConsumer<K, V>) = object : ConsumerRebalanceListener {
+        override fun onPartitionsRevoked(partitions: MutableCollection<TopicPartition>) {
+            log.info { "Partitions revoked $partitions, committing offsets" }
+            commitOffsets(consumer)
+        }
+
+        override fun onPartitionsAssigned(partitions: MutableCollection<TopicPartition>) {
+            log.info { "Partitions assigned $partitions" }
+        }
+    }
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/Producer.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/Producer.kt
@@ -1,0 +1,64 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.kafka.config.KafkaConfig
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import java.time.Duration
+
+class Producer<K, V>(
+    kafkaConfig: KafkaConfig,
+    gracePeriodMillis: Long = 1000,
+) {
+    private val log = KotlinLogging.logger {}
+    private val producer = KafkaProducer<K, V>(kafkaConfig.producerConfig())
+
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                log.info { "Shutting down Kafka producer in $gracePeriodMillis milliseconds..." }
+                Thread.sleep(Duration.ofMillis(gracePeriodMillis))
+                producer.close()
+            },
+        )
+    }
+
+    fun produce(
+        topic: String,
+        key: K,
+        value: V,
+    ) {
+        val record = ProducerRecord(
+            topic,
+            key,
+            value,
+        )
+
+        val metadata = producer.send(record).get()
+
+        log.info {
+            "Produserte melding til topic ${metadata.topic()}, " +
+                "key=$key, " +
+                "offset=${metadata.offset()}, " +
+                "partition=${metadata.partition()}"
+        }
+    }
+
+    fun tombstone(topic: String, key: K) {
+        val value: V? = null
+        val record = ProducerRecord(
+            topic,
+            key,
+            value,
+        )
+
+        val metadata = producer.send(record).get()
+
+        log.info {
+            "Produserte tombstone til topic ${metadata.topic()}, " +
+                "key=$key, " +
+                "offset=${metadata.offset()}, " +
+                "partition=${metadata.partition()}"
+        }
+    }
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/config/KafkaConfig.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/config/KafkaConfig.kt
@@ -1,0 +1,15 @@
+package no.nav.tiltakspenger.libs.kafka.config
+
+import org.apache.kafka.common.serialization.Deserializer
+
+interface KafkaConfig {
+    fun commonConfig(): Map<String, *>
+
+    fun <K, V> consumerConfig(
+        keyDeserializer: Deserializer<K>,
+        valueDeserializer: Deserializer<V>,
+        groupId: String,
+    ): Map<String, *>
+
+    fun producerConfig(): Map<String, *>
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/config/KafkaConfigImpl.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/config/KafkaConfigImpl.kt
@@ -1,0 +1,66 @@
+package no.nav.tiltakspenger.libs.kafka.config
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.StringSerializer
+
+const val MAX_POLL_INTERVAL_MS = 300_000
+
+class KafkaConfigImpl(
+    private val autoOffsetReset: String = "earliest",
+) : KafkaConfig {
+    private val javaKey: String = "JKS"
+    private val pkcs12: String = "PKCS12"
+
+    private val kafkaBrokers = getEnvVar("KAFKA_BROKERS")
+    private val kafkaTruststorePath = getEnvVar("KAFKA_TRUSTSTORE_PATH")
+    private val kafkaCredstorePassword = getEnvVar("KAFKA_CREDSTORE_PASSWORD")
+    private val kafkaKeystorePath = getEnvVar("KAFKA_KEYSTORE_PATH")
+    private val kafkaSecurityProtocol = "SSL"
+
+    override fun commonConfig() = mapOf(
+        BOOTSTRAP_SERVERS_CONFIG to kafkaBrokers,
+    ) + securityConfig()
+
+    private fun securityConfig() = mapOf(
+        CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to kafkaSecurityProtocol,
+        SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG to "", // Disable server host name verification
+        SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG to javaKey,
+        SslConfigs.SSL_KEYSTORE_TYPE_CONFIG to pkcs12,
+        SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG to kafkaTruststorePath,
+        SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG to kafkaCredstorePassword,
+        SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG to kafkaKeystorePath,
+        SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG to kafkaCredstorePassword,
+        SslConfigs.SSL_KEY_PASSWORD_CONFIG to kafkaCredstorePassword,
+    )
+
+    override fun <K, V> consumerConfig(
+        keyDeserializer: Deserializer<K>,
+        valueDeserializer: Deserializer<V>,
+        groupId: String,
+    ) = mapOf(
+        ConsumerConfig.GROUP_ID_CONFIG to groupId,
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to autoOffsetReset,
+        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to keyDeserializer::class.java,
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to valueDeserializer::class.java,
+        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS,
+    ) + commonConfig()
+
+    override fun producerConfig() = mapOf(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+        ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG to true,
+        ProducerConfig.ACKS_CONFIG to "all",
+        ProducerConfig.RETRIES_CONFIG to Int.MAX_VALUE,
+        ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION to 5,
+    ) + commonConfig()
+
+    private fun getEnvVar(varName: String, defaultValue: String = "") = System.getenv(varName)
+        ?: System.getProperty(varName)
+        ?: defaultValue
+}

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/config/LocalKafkaConfig.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/config/LocalKafkaConfig.kt
@@ -1,0 +1,38 @@
+package no.nav.tiltakspenger.libs.kafka.config
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.StringSerializer
+
+class LocalKafkaConfig(
+    private val kafkaBrokers: String = System.getenv("KAFKA_BROKERS") ?: "localhost:9092",
+    private val kafkaAutoOffsetReset: String = "earliest",
+) : KafkaConfig {
+    override fun commonConfig() = mapOf(
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG to kafkaBrokers,
+    )
+
+    override fun <K, V> consumerConfig(
+        keyDeserializer: Deserializer<K>,
+        valueDeserializer: Deserializer<V>,
+        groupId: String,
+    ) = mapOf(
+        ConsumerConfig.GROUP_ID_CONFIG to groupId,
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to kafkaAutoOffsetReset,
+        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to keyDeserializer::class.java,
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to valueDeserializer::class.java,
+        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS,
+    ) + commonConfig()
+
+    override fun producerConfig() = mapOf(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+        ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG to true,
+        ProducerConfig.ACKS_CONFIG to "all",
+        ProducerConfig.RETRIES_CONFIG to Int.MAX_VALUE,
+        ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION to 5,
+    ) + commonConfig()
+}

--- a/kafka/test/no/nav/tiltakspenger/libs/kafka/ConsumerStatusTest.kt
+++ b/kafka/test/no/nav/tiltakspenger/libs/kafka/ConsumerStatusTest.kt
@@ -1,0 +1,46 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ConsumerStatusTest {
+    @Test
+    fun `retries - øker for hver failure`() {
+        val status = ConsumerStatus()
+        val feil = 42
+
+        repeat(42) { status.failure() }
+
+        status.retries shouldBe feil
+        status.isFailure shouldBe true
+    }
+
+    @Test
+    fun `retries - resettes til 0 etter success`() {
+        val status = ConsumerStatus()
+        val feil = 7
+
+        repeat(7) { status.failure() }
+
+        status.retries shouldBe feil
+        status.isFailure shouldBe true
+
+        status.success()
+
+        status.retries shouldBe 0
+        status.isFailure shouldBe false
+    }
+
+    @Test
+    fun `backoffDuration - skal aldri være større enn MAX_DELAY`() {
+        val status = ConsumerStatus()
+
+        repeat(25) { status.failure() }
+
+        status.backoffDuration shouldBe ConsumerStatus.MAX_DELAY
+
+        status.failure()
+
+        status.backoffDuration shouldBe ConsumerStatus.MAX_DELAY
+    }
+}

--- a/kafka/test/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumerTest.kt
+++ b/kafka/test/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumerTest.kt
@@ -1,0 +1,217 @@
+package no.nav.tiltakspenger.libs.kafka
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.libs.kafka.config.LocalKafkaConfig
+import no.nav.tiltakspenger.libs.kafka.test.SingletonKafkaProvider
+import no.nav.tiltakspenger.libs.kafka.test.eventually
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.IntegerDeserializer
+import org.apache.kafka.common.serialization.IntegerSerializer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.common.serialization.UUIDDeserializer
+import org.apache.kafka.common.serialization.UUIDSerializer
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+
+class ManagedKafkaConsumerTest {
+    private val topic = "test.topic"
+
+    private val stringConsumerConfig = LocalKafkaConfig(SingletonKafkaProvider.getHost())
+        .consumerConfig(
+            keyDeserializer = StringDeserializer(),
+            valueDeserializer = StringDeserializer(),
+            groupId = "test-consumer-${UUID.randomUUID()}",
+        )
+
+    private val intConsumerConfig = LocalKafkaConfig(SingletonKafkaProvider.getHost())
+        .consumerConfig(
+            keyDeserializer = IntegerDeserializer(),
+            valueDeserializer = IntegerDeserializer(),
+            groupId = "test-consumer-${UUID.randomUUID()}",
+        )
+
+    @Test
+    fun `ManagedKafkaConsumer - konsumerer record med String, String`() {
+        val key = "key"
+        val value = "value"
+        val cache = mutableMapOf<String, String>()
+
+        produceStringString(ProducerRecord(topic, key, value))
+
+        val consumer = ManagedKafkaConsumer(topic, stringConsumerConfig) { k: String, v: String ->
+            cache[k] = v
+        }
+        consumer.run()
+
+        eventually {
+            cache[key] shouldBe value
+            consumer.stop()
+        }
+    }
+
+    @Test
+    fun `ManagedKafkaConsumer - konsumerer record med UUID, ByteArray`() {
+        val key = UUID.randomUUID()
+        val value = "value".toByteArray()
+        val cache = mutableMapOf<UUID, ByteArray>()
+        val uuidTopic = "uuid.topic"
+
+        produceUUIDByteArray(ProducerRecord(uuidTopic, key, value))
+
+        val config = LocalKafkaConfig(SingletonKafkaProvider.getHost())
+            .consumerConfig(
+                keyDeserializer = UUIDDeserializer(),
+                valueDeserializer = ByteArrayDeserializer(),
+                groupId = "test-consumer-${UUID.randomUUID()}",
+            )
+
+        val consumer = ManagedKafkaConsumer(uuidTopic, config) { k: UUID, v: ByteArray ->
+            cache[k] = v
+        }
+        consumer.run()
+
+        eventually {
+            cache[key] shouldBe value
+            consumer.stop()
+        }
+    }
+
+    @Test
+    fun `ManagedKafkaConsumer - prøver å konsumere melding på nytt hvis noe feiler`() {
+        val key = "key"
+        val value = "value"
+
+        var antallGangerKallt = 0
+
+        produceStringString(ProducerRecord(topic, key, value))
+
+        val consumer = ManagedKafkaConsumer<String, String>(topic, stringConsumerConfig) { _, _ ->
+            antallGangerKallt++
+            error("skal feile noen ganger")
+        }
+        consumer.run()
+
+        eventually {
+            antallGangerKallt shouldBe 2
+            consumer.status.retries shouldBe antallGangerKallt
+            consumer.stop()
+        }
+    }
+
+    @Test
+    fun `ManagedKafkaConsumer - konsumerer mange meldinger med feil og flere partisjoner`() {
+        val intTopic = NewTopic("int.topic-1", 4, 1)
+        SingletonKafkaProvider.adminClient
+            .createTopics(listOf(intTopic))
+            .all()
+            .get()
+
+        val data = (1..100).toList()
+        val consumed = mutableListOf<Int>()
+        val failures = mutableListOf(7, 42, 42, 93)
+
+        val consumer = ManagedKafkaConsumer<Int, Int>(intTopic.name(), intConsumerConfig) { k, _ ->
+            if (k in failures) {
+                failures.remove(k)
+                error("Skal feile på $k")
+            }
+            consumed.add(k)
+        }
+
+        consumer.start()
+        data.forEach {
+            val partition = (0..3).random()
+            produceIntInt(ProducerRecord(intTopic.name(), partition, it, it))
+        }
+
+        eventually(Duration.ofSeconds(15)) {
+            consumed.size shouldBe data.size
+            consumed.toSet().size shouldBe data.size
+            consumer.stop()
+        }
+    }
+
+    @Test
+    fun `ManagedKafkaConsumer - konsumerer mange meldinger med samme key i riktig rekkefølge`() {
+        val intTopic = NewTopic("int.topic-2", 4, 1)
+        SingletonKafkaProvider.adminClient
+            .createTopics(listOf(intTopic))
+            .all()
+            .get()
+
+        val keys = (1..20).toList()
+        val firstValue = 1
+        val lastValue = 2
+        val data = keys.map { Pair(it, firstValue) } + keys.map { Pair(it, lastValue) }
+
+        val consumed = mutableMapOf<Int, Int>()
+        val failures = mutableListOf(7, 42, 42)
+        val consumer = ManagedKafkaConsumer<Int, Int>(intTopic.name(), intConsumerConfig) { k, v ->
+            if (k in failures) {
+                failures.remove(k)
+                error("Skal feile på $k")
+            }
+            if (v == lastValue) {
+                consumed[k] shouldBe firstValue
+            }
+            consumed[k] = v
+        }
+
+        consumer.start()
+
+        data.forEach {
+            val partition = it.first % intTopic.numPartitions()
+            produceIntInt(ProducerRecord(intTopic.name(), partition, it.first, it.second))
+        }
+
+        eventually(Duration.ofSeconds(15)) {
+            consumed.values.toSet() shouldBe setOf(lastValue)
+            consumer.stop()
+        }
+    }
+}
+
+private fun produceIntInt(record: ProducerRecord<Int, Int>): RecordMetadata {
+    KafkaProducer<Int, Int>(
+        Properties().apply {
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, SingletonKafkaProvider.getHost())
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer::class.java)
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer::class.java)
+        },
+    ).use { producer ->
+        return producer.send(record).get()
+    }
+}
+
+private fun produceStringString(record: ProducerRecord<String, String>): RecordMetadata {
+    KafkaProducer<String, String>(
+        Properties().apply {
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, SingletonKafkaProvider.getHost())
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+        },
+    ).use { producer ->
+        return producer.send(record).get()
+    }
+}
+
+private fun produceUUIDByteArray(record: ProducerRecord<UUID, ByteArray>): RecordMetadata {
+    KafkaProducer<UUID, ByteArray>(
+        Properties().apply {
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, SingletonKafkaProvider.getHost())
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, UUIDSerializer::class.java)
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer::class.java)
+        },
+    ).use { producer ->
+        return producer.send(record).get()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,5 +22,7 @@ include(
     "ktor-test-common",
     "logging",
     "datadeling-dtos",
-    "meldekort-dtos"
+    "meldekort-dtos",
+    "kafka",
+    "kafka-test"
 )


### PR DESCRIPTION
## Beskrivelse
Legger inn generelt oppsett for kafka så det er raskt å sette opp i de ulike appene våre når det trengs. Oppsettet er lånt fra Komet 🙇‍♀️ 

Kafka-modulen inneholder oppsett for kjøring i dev og prod, og for kjøring lokalt/i tester. Configverdiene som er satt er greie defaults som brukes av omtrent alle i Nav. 

Kafka-test-modulen inneholder et enkelt ferdig oppsett for å kunne bruke kafka testcontainers i tester i appene. Det går an å legge til en reuse-strategi på denne hvis vi ønsker å gjenbruke den for å få ned byggetid, men jeg tok det ikke med i første omgang. 

## Kommentarer
Relatert til https://trello.com/c/xwqA0nvR/1313-saksbehandler-m%C3%A5-f%C3%A5-vite-om-relevante-endringer-i-tiltaksdeltakelsen
