### PR TITLE
1119 flytter mapping av mottatte arena- og kometstatuser ut i libs

### DIFF
--- a/arenatiltak-dtos/build.gradle.kts
+++ b/arenatiltak-dtos/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(project(":tiltak-dtos"))
+}

--- a/arenatiltak-dtos/main/no/nav/tiltakspenger/libs/arena/tiltak/ArenaDeltakerStatusType.kt
+++ b/arenatiltak-dtos/main/no/nav/tiltakspenger/libs/arena/tiltak/ArenaDeltakerStatusType.kt
@@ -1,0 +1,45 @@
+package no.nav.tiltakspenger.libs.arena.tiltak
+
+import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO
+import java.time.LocalDate
+
+enum class ArenaDeltakerStatusType(val navn: String) {
+    AKTUELL("Aktuell"),
+    AVSLAG("Fått avslag"),
+    DELAVB("Deltakelse avbrutt"),
+    FULLF("Fullført"),
+    GJENN("Gjennomføres"),
+    GJENN_AVB("Gjennomføring avbrutt"),
+    GJENN_AVL("Gjennomføring avlyst"),
+    IKKAKTUELL("Ikke aktuell"),
+    IKKEM("Ikke møtt"),
+    INFOMOETE("Informasjonsmøte"),
+    JATAKK("Takket ja til tilbud"),
+    NEITAKK("Takket nei til tilbud"),
+    TILBUD("Godkjent tiltaksplass"),
+    VENTELISTE("Venteliste"),
+    FEILREG("Feilregistrert"),
+}
+
+fun ArenaDeltakerStatusType.toDTO(fom: LocalDate?): TiltakResponsDTO.DeltakerStatusDTO {
+    val startdatoErFremITid = fom == null || fom.isAfter(LocalDate.now())
+
+    return when (this) {
+        ArenaDeltakerStatusType.DELAVB -> TiltakResponsDTO.DeltakerStatusDTO.AVBRUTT
+        ArenaDeltakerStatusType.FULLF -> TiltakResponsDTO.DeltakerStatusDTO.FULLFORT
+        ArenaDeltakerStatusType.GJENN -> if (startdatoErFremITid) TiltakResponsDTO.DeltakerStatusDTO.VENTER_PA_OPPSTART else TiltakResponsDTO.DeltakerStatusDTO.DELTAR
+        ArenaDeltakerStatusType.GJENN_AVB -> TiltakResponsDTO.DeltakerStatusDTO.AVBRUTT
+        ArenaDeltakerStatusType.IKKEM -> TiltakResponsDTO.DeltakerStatusDTO.AVBRUTT
+        ArenaDeltakerStatusType.JATAKK -> TiltakResponsDTO.DeltakerStatusDTO.DELTAR
+        ArenaDeltakerStatusType.TILBUD -> if (startdatoErFremITid) TiltakResponsDTO.DeltakerStatusDTO.VENTER_PA_OPPSTART else TiltakResponsDTO.DeltakerStatusDTO.DELTAR
+
+        ArenaDeltakerStatusType.AKTUELL -> TiltakResponsDTO.DeltakerStatusDTO.SOKT_INN
+        ArenaDeltakerStatusType.AVSLAG -> TiltakResponsDTO.DeltakerStatusDTO.IKKE_AKTUELL
+        ArenaDeltakerStatusType.GJENN_AVL -> TiltakResponsDTO.DeltakerStatusDTO.IKKE_AKTUELL
+        ArenaDeltakerStatusType.IKKAKTUELL -> TiltakResponsDTO.DeltakerStatusDTO.IKKE_AKTUELL
+        ArenaDeltakerStatusType.INFOMOETE -> TiltakResponsDTO.DeltakerStatusDTO.VENTELISTE
+        ArenaDeltakerStatusType.NEITAKK -> TiltakResponsDTO.DeltakerStatusDTO.IKKE_AKTUELL
+        ArenaDeltakerStatusType.VENTELISTE -> TiltakResponsDTO.DeltakerStatusDTO.VENTELISTE
+        ArenaDeltakerStatusType.FEILREG -> TiltakResponsDTO.DeltakerStatusDTO.FEILREGISTRERT
+    }
+}

--- a/arenatiltak-dtos/main/no/nav/tiltakspenger/libs/arena/tiltak/ArenaTiltaksaktivitetResponsDTO.kt
+++ b/arenatiltak-dtos/main/no/nav/tiltakspenger/libs/arena/tiltak/ArenaTiltaksaktivitetResponsDTO.kt
@@ -19,7 +19,7 @@ data class ArenaTiltaksaktivitetResponsDTO(
         val bedriftsnummer: String?,
         val deltakelsePeriode: DeltakelsesPeriodeDTO?,
         val deltakelseProsent: Float?,
-        val deltakerStatusType: DeltakerStatusType,
+        val deltakerStatusType: ArenaDeltakerStatusType,
         val statusSistEndret: LocalDate?,
         val begrunnelseInnsoeking: String?,
         val antallDagerPerUke: Float?,
@@ -168,23 +168,5 @@ data class ArenaTiltaksaktivitetResponsDTO(
         NYTEST("Nytt testtiltak", Tiltaksgruppe.ARBTREN, false),
         INDOPPRF("Resultatbasert finansiering av formidlingsbistand", Tiltaksgruppe.FORSOK, true),
         SUPPEMP("Supported Employment", Tiltaksgruppe.FORSOK, true),
-    }
-
-    enum class DeltakerStatusType(val navn: String) {
-        AKTUELL("Aktuell"),
-        AVSLAG("Fått avslag"),
-        DELAVB("Deltakelse avbrutt"),
-        FULLF("Fullført"),
-        GJENN("Gjennomføres"),
-        GJENN_AVB("Gjennomføring avbrutt"),
-        GJENN_AVL("Gjennomføring avlyst"),
-        IKKAKTUELL("Ikke aktuell"),
-        IKKEM("Ikke møtt"),
-        INFOMOETE("Informasjonsmøte"),
-        JATAKK("Takket ja til tilbud"),
-        NEITAKK("Takket nei til tilbud"),
-        TILBUD("Godkjent tiltaksplass"),
-        VENTELISTE("Venteliste"),
-        FEILREG("Feilregistrert"),
     }
 }

--- a/tiltak-dtos/main/no/nav/tiltakspenger/libs/tiltak/KometDeltakerStatusType.kt
+++ b/tiltak-dtos/main/no/nav/tiltakspenger/libs/tiltak/KometDeltakerStatusType.kt
@@ -1,0 +1,39 @@
+package no.nav.tiltakspenger.libs.tiltak
+
+import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO
+
+enum class KometDeltakerStatusType {
+    UTKAST_TIL_PAMELDING,
+    AVBRUTT_UTKAST,
+    VENTER_PA_OPPSTART,
+    DELTAR,
+    HAR_SLUTTET,
+    IKKE_AKTUELL,
+    FEILREGISTRERT,
+    SOKT_INN,
+    VURDERES,
+    VENTELISTE,
+    AVBRUTT,
+    FULLFORT,
+    PABEGYNT_REGISTRERING,
+}
+
+fun KometDeltakerStatusType.toDeltakerStatusDTO(): TiltakResponsDTO.DeltakerStatusDTO = when (this) {
+    KometDeltakerStatusType.UTKAST_TIL_PAMELDING,
+    KometDeltakerStatusType.PABEGYNT_REGISTRERING,
+    -> DeltakerStatusDTO.PABEGYNT_REGISTRERING
+
+    KometDeltakerStatusType.AVBRUTT_UTKAST,
+    KometDeltakerStatusType.IKKE_AKTUELL,
+    -> DeltakerStatusDTO.IKKE_AKTUELL
+
+    KometDeltakerStatusType.VENTER_PA_OPPSTART -> DeltakerStatusDTO.VENTER_PA_OPPSTART
+    KometDeltakerStatusType.DELTAR -> DeltakerStatusDTO.DELTAR
+    KometDeltakerStatusType.HAR_SLUTTET -> DeltakerStatusDTO.HAR_SLUTTET
+    KometDeltakerStatusType.FEILREGISTRERT -> DeltakerStatusDTO.FEILREGISTRERT
+    KometDeltakerStatusType.SOKT_INN -> DeltakerStatusDTO.SOKT_INN
+    KometDeltakerStatusType.VURDERES -> DeltakerStatusDTO.VURDERES
+    KometDeltakerStatusType.VENTELISTE -> DeltakerStatusDTO.VENTELISTE
+    KometDeltakerStatusType.AVBRUTT -> DeltakerStatusDTO.AVBRUTT
+    KometDeltakerStatusType.FULLFORT -> DeltakerStatusDTO.FULLFORT
+}


### PR DESCRIPTION
## Beskrivelse
Siden både tiltakspenger-tiltak og tiltakspenger-saksbehandling-api må mappe disse statusene flytter jeg mappingen til libs så vi slipper duplisering og å måtte endre flere steder ved oppdatering. Siden jeg endret navnet på statustype-enumen for Arena må jeg også oppdatere litt i tiltakspenger-arena, men jeg tror det blir lettere å holde statustypene fra hverandre på denne måten. 

## Kommentarer
https://trello.com/c/xIpArfVl/1119-hvordan-filtrere-mutere-tiltaksdeltagelser-fra-registere
