### PR TITLE
fjerner tiltaksinformasjon som ikke brukes

### DIFF
--- a/datadeling-dtos/main/no/nav/tiltakspenger/libs/datadeling/DatadelingBehandlingDTO.kt
+++ b/datadeling-dtos/main/no/nav/tiltakspenger/libs/datadeling/DatadelingBehandlingDTO.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.libs.datadeling
 
-import no.nav.tiltakspenger.libs.json.serialize
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -13,8 +12,6 @@ data class DatadelingBehandlingDTO(
     val saksbehandler: String?,
     val beslutter: String?,
     val iverksattTidspunkt: LocalDateTime?,
-    val tiltak: DatadelingTiltakDTO,
-
     val fnr: String,
     val saksnummer: String,
     val søknadJournalpostId: String,
@@ -28,12 +25,3 @@ data class DatadelingBehandlingDTO(
         VEDTATT,
     }
 }
-
-data class DatadelingTiltakDTO(
-    val tiltakNavn: String,
-    val eksternTiltakdeltakerId: String,
-    val gjennomføringId: String?,
-)
-
-internal fun DatadelingTiltakDTO.toDbJson(): String =
-    serialize(this)


### PR DESCRIPTION
## Beskrivelse
Vi bruker ikke tiltaksinformasjonen og ved å fjerne den slipper vi å ta stilling til hvordan den evt skal kunne lagres og deles periodisert. 

## Kommentarer
https://trello.com/c/W9ifbenn/1315-st%C3%B8tte-at-vi-f%C3%A5r-flere-tiltak-fra-arena-komet-n%C3%A5r-vi-s%C3%B8ker-opp-et-fnr