### PR TITLE
1187 oppgraderer kotlinlogging

### DIFF
--- a/auth-core/main/no/nav/tiltakspenger/libs/auth/core/EntraIdSystemtokenHttpClient.kt
+++ b/auth-core/main/no/nav/tiltakspenger/libs/auth/core/EntraIdSystemtokenHttpClient.kt
@@ -5,11 +5,11 @@ import arrow.core.getOrElse
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Expiry
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.withContext
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.json.lesTre
 import no.nav.tiltakspenger.libs.logging.sikkerlogg
@@ -86,7 +86,7 @@ class EntraIdSystemtokenHttpClient(
             val jsonResponse = httpResponse.body()
             val status = httpResponse.statusCode()
             if (status != 200) {
-                sikkerlogg.error("Feil ved henting av systemtoken mot $otherAppId. Status: $status. jsonResponse: $jsonResponse. uri: $uri.")
+                sikkerlogg.error { "Feil ved henting av systemtoken mot $otherAppId. Status: $status. jsonResponse: $jsonResponse. uri: $uri." }
                 throw RuntimeException("Feil ved henting av systemtoken mot $otherAppId. Status: $status. uri: $uri. Se sikkerlogg for detaljer.")
             }
             Either.catch {

--- a/auth-core/main/no/nav/tiltakspenger/libs/auth/core/MicrosoftEntraIdTokenService.kt
+++ b/auth-core/main/no/nav/tiltakspenger/libs/auth/core/MicrosoftEntraIdTokenService.kt
@@ -11,9 +11,10 @@ import com.auth0.jwk.SigningKeyNotFoundException
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.DecodedJWT
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.auth.core.Valideringsfeil.UgyldigToken.KunneIkkeVerifisereToken
 import no.nav.tiltakspenger.libs.auth.core.Valideringsfeil.UgyldigToken.ManglerClaim
 import no.nav.tiltakspenger.libs.auth.core.Valideringsfeil.UgyldigToken.UlikKid
@@ -55,8 +56,8 @@ class MicrosoftEntraIdTokenService<SB : GenerellSystembruker<GenerellSystembruke
         .cached(10, 24, TimeUnit.HOURS)
         .rateLimited(10, 1, TimeUnit.MINUTES)
         .build(),
-    private val sikkerlogg: mu.KLogger? = no.nav.tiltakspenger.libs.logging.sikkerlogg,
-    private val logger: mu.KLogger? = KotlinLogging.logger { },
+    private val sikkerlogg: KLogger? = no.nav.tiltakspenger.libs.logging.sikkerlogg,
+    private val logger: KLogger? = KotlinLogging.logger { },
 ) : TokenService {
 
     /**

--- a/auth-ktor/main/no/nav/tiltakspenger/libs/auth/ktor/ApplicationCallAutentiseringEx.kt
+++ b/auth-ktor/main/no/nav/tiltakspenger/libs/auth/ktor/ApplicationCallAutentiseringEx.kt
@@ -1,9 +1,10 @@
 package no.nav.tiltakspenger.libs.auth.ktor
 
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
-import mu.KLogger
 import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.libs.auth.core.Valideringsfeil
 import no.nav.tiltakspenger.libs.common.Bruker
@@ -18,7 +19,7 @@ import kotlin.text.substring
 
 suspend inline fun ApplicationCall.withSaksbehandler(
     tokenService: TokenService,
-    logger: KLogger = mu.KotlinLogging.logger {},
+    logger: KLogger = KotlinLogging.logger {},
     svarMed403HvisIngenSaksbehandlerRoller: Boolean = true,
     svarMed403HvisIngenScopes: Boolean = true,
     crossinline block: suspend (Saksbehandler) -> Unit,
@@ -43,7 +44,7 @@ suspend inline fun ApplicationCall.withSaksbehandler(
 
 suspend inline fun <reified B : GenerellSystembruker<*, *>> ApplicationCall.withSystembruker(
     tokenService: TokenService,
-    logger: KLogger = mu.KotlinLogging.logger {},
+    logger: KLogger = KotlinLogging.logger {},
     svarMed403HvisIngenSystembrukerRoller: Boolean = true,
     crossinline block: suspend (B) -> Unit,
 ) {
@@ -68,7 +69,7 @@ suspend inline fun <reified B : GenerellSystembruker<*, *>> ApplicationCall.with
 
 suspend inline fun <reified B : Bruker<*, *>> ApplicationCall.withBruker(
     tokenService: TokenService,
-    logger: KLogger = mu.KotlinLogging.logger {},
+    logger: KLogger = KotlinLogging.logger {},
     svarMed403HvisIngenSaksbehandlerRoller: Boolean = true,
     svarMed403HvisIngenSystembrukerRoller: Boolean = true,
     svarMed403HvisIngenScopes: Boolean = true,

--- a/auth-ktor/test/ApplicationCallAutentiseringExTest.kt
+++ b/auth-ktor/test/ApplicationCallAutentiseringExTest.kt
@@ -24,7 +24,6 @@ import no.nav.tiltakspenger.libs.auth.test.core.tokenServiceForTest
 import no.nav.tiltakspenger.libs.json.objectMapper
 import no.nav.tiltakspenger.libs.ktor.test.common.defaultRequest
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 
 internal class ApplicationCallAutentiseringExTest {
 
@@ -102,9 +101,6 @@ internal class ApplicationCallAutentiseringExTest {
 
     @Test
     fun `Brukeren er ikke saksbehandler`() {
-        val resource = Thread.currentThread().contextClassLoader.getResource("logback-test.xml")
-        println("Logback test config path: $resource")
-        println("Logger factory: ${LoggerFactory.getILoggerFactory()}")
         runTest {
             testApplication {
                 val jwtGenerator = JwtGenerator()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     implementation("io.arrow-kt:arrow-core:2.0.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation("com.aallam.ulid:ulid-kotlin:1.3.0")
+    implementation("org.slf4j:slf4j-api:2.0.17")
 
     testImplementation(project(":test-common"))
 }

--- a/common/main/no/nav/tiltakspenger/libs/common/CorrelationIdEx.kt
+++ b/common/main/no/nav/tiltakspenger/libs/common/CorrelationIdEx.kt
@@ -1,8 +1,8 @@
 package no.nav.tiltakspenger.libs.common
 
 import arrow.core.Either
+import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.coroutines.runBlocking
-import mu.KLogger
 import org.slf4j.MDC
 
 /**
@@ -46,7 +46,7 @@ suspend fun withCorrelationIdSuspend(
         Either.catch {
             MDC.remove(mdcKey)
         }.onLeft {
-            logger.error("En ukjent feil skjedde når vi prøvde fjerne $mdcKey fra MDC.", it)
+            logger.error(it) { "En ukjent feil skjedde når vi prøvde fjerne $mdcKey fra MDC." }
         }
     }
 }
@@ -56,9 +56,6 @@ private fun getCorrelationIdFromThreadLocal(
     mdcKey: String,
 ): CorrelationId? {
     return MDC.get(mdcKey)?.let { CorrelationId(it) } ?: null.also {
-        logger.error(
-            "Mangler '$mdcKey' på MDC. Er dette et asynk-kall? Da må det settes manuelt, så tidlig som mulig.",
-            RuntimeException("Genererer en stacktrace for enklere debugging."),
-        )
+        logger.error(RuntimeException("Genererer en stacktrace for enklere debugging.")) { "Mangler '$mdcKey' på MDC. Er dette et asynk-kall? Da må det settes manuelt, så tidlig som mulig." }
     }
 }

--- a/jobber/main/no/nav/tiltakspenger/libs/jobber/LeaderPodLookupClient.kt
+++ b/jobber/main/no/nav/tiltakspenger/libs/jobber/LeaderPodLookupClient.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.flatten
 import arrow.core.left
 import arrow.core.right
+import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.atomicfu.atomic
-import mu.KLogger
 import no.nav.tiltakspenger.libs.json.objectMapper
 import java.net.URI
 import java.net.http.HttpClient
@@ -47,16 +47,16 @@ class LeaderPodLookupClient(
                     Either.catch {
                         objectMapper.readTree(body).get("name").asText(null)
                     }.mapLeft {
-                        logger.error("LeaderPodLookup: json-respons fra leader-elector sidecar manglet keyen 'name'. Uri: $uri, body: $body, status: ${httpResponse.statusCode()}")
+                        logger.error { "LeaderPodLookup: json-respons fra leader-elector sidecar manglet keyen 'name'. Uri: $uri, body: $body, status: ${httpResponse.statusCode()}" }
                         LeaderPodLookupFeil.UkjentSvarFraLeaderElectorContainer
                     }
                 } else {
-                    logger.error("LeaderPodLookup: Klarte ikke å kontakte leader-elector sidecar på uri $uri. Fikk status ${httpResponse.statusCode()} og body: $body")
+                    logger.error { "LeaderPodLookup: Klarte ikke å kontakte leader-elector sidecar på uri $uri. Fikk status ${httpResponse.statusCode()} og body: $body" }
                     LeaderPodLookupFeil.Ikke2xx(httpResponse.statusCode(), body).left()
                 }
             }
         }.mapLeft {
-            logger.error("Klarte ikke å kontakte leader-elector-containeren", it)
+            logger.error(it) { "Klarte ikke å kontakte leader-elector-containeren" }
             LeaderPodLookupFeil.KunneIkkeKontakteLeaderElectorContainer
         }.flatten().map { leaderHostname ->
             logger.debug { "Fant leder med navn '$leaderHostname'. Mitt hostname er '$localHostName'." }

--- a/jobber/main/no/nav/tiltakspenger/libs/jobber/StoppableJob.kt
+++ b/jobber/main/no/nav/tiltakspenger/libs/jobber/StoppableJob.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.libs.jobber
 
 import arrow.core.Either
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.withCorrelationId
 import java.time.Duration
@@ -111,23 +111,21 @@ private fun startStoppableJob(
         Either.catch {
             if (runJobCheck.shouldRun()) {
                 if (enableDebuggingLogging) {
-                    log.debug("Kjører skeduleringsjobb '$jobName'.")
+                    log.debug { "Kjører skeduleringsjobb '$jobName'." }
                 }
                 withCorrelationId(log, mdcCallIdKey) { job(it) }
                 if (enableDebuggingLogging) {
-                    log.debug("Fullførte skeduleringsjobb '$jobName'.")
+                    log.debug { "Fullførte skeduleringsjobb '$jobName'." }
                 }
             } else {
                 if (enableDebuggingLogging) {
-                    log.debug("Skeduleringsjobb '$jobName' kjører ikke pga. startKriterier i runJobCheck. Eksempelvis er vi ikke leader pod.")
+                    log.debug { "Skeduleringsjobb '$jobName' kjører ikke pga. startKriterier i runJobCheck. Eksempelvis er vi ikke leader pod." }
                 }
             }
         }.onLeft {
-            log.error(
-                "Skeduleringsjobb '$jobName' feilet. Se sikkerlog for mer kontekst.",
-                RuntimeException("Trigger stacktrace for enklere debug."),
-            )
-            sikkerLogg.error("Skeduleringsjobb '$jobName' feilet med stacktrace:", it)
+            log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Skeduleringsjobb '$jobName' feilet. Se sikkerlog for mer kontekst." }
+
+            sikkerLogg.error(it) { "Skeduleringsjobb '$jobName' feilet med stacktrace:" }
         }
     }.let { timer ->
         object : StoppableJob {
@@ -140,7 +138,7 @@ private fun startStoppableJob(
                         "Skeduleringsjobb '$jobName' stoppet. Pågående kjøringer ferdigstilles."
                     }
                 }.onLeft {
-                    log.error("Skeduleringsjobb '$jobName': Feil ved kall til stop()/kanseller Timer.", it)
+                    log.error(it) { "Skeduleringsjobb '$jobName': Feil ved kall til stop()/kanseller Timer." }
                 }
             }
         }

--- a/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/SingletonKafkaProvider.kt
+++ b/kafka-test/main/no/nav/tiltakspenger/libs/kafka/test/SingletonKafkaProvider.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltakspenger.libs.kafka.test
 
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.testcontainers.kafka.KafkaContainer

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumer.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumer.kt
@@ -1,11 +1,11 @@
 package no.nav.tiltakspenger.libs.kafka
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import mu.KotlinLogging
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords

--- a/kafka/main/no/nav/tiltakspenger/libs/kafka/Producer.kt
+++ b/kafka/main/no/nav/tiltakspenger/libs/kafka/Producer.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltakspenger.libs.kafka
 
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.kafka.config.KafkaConfig
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord

--- a/ktor-common/main/no/nav/tiltakspenger/libs/ktor/common/ApplicationCallEx.kt
+++ b/ktor-common/main/no/nav/tiltakspenger/libs/ktor/common/ApplicationCallEx.kt
@@ -1,10 +1,10 @@
 package no.nav.tiltakspenger.libs.ktor.common
 
 import arrow.core.Either
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveText
-import mu.KLogger
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.json.deserialize
 import no.nav.tiltakspenger.libs.logging.sikkerlogg
 

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api("io.github.microutils:kotlin-logging-jvm:3.0.5")
+    api("io.github.oshai:kotlin-logging-jvm:7.0.5")
 
     testImplementation(project(":test-common"))
 }

--- a/logging/main/no/nav/tiltakspenger/libs/logging/Sikkerlogg.kt
+++ b/logging/main/no/nav/tiltakspenger/libs/logging/Sikkerlogg.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltakspenger.libs.logging
 
-import mu.KLogger
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 val sikkerlogg: KLogger by lazy { KotlinLogging.logger("tjenestekall") }

--- a/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresSessionContext.kt
+++ b/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresSessionContext.kt
@@ -2,13 +2,13 @@ package no.nav.tiltakspenger.libs.persistering.infrastruktur
 
 import arrow.core.Either
 import arrow.core.getOrElse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Session
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
-import org.slf4j.LoggerFactory
 import javax.sql.DataSource
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresTransactionContext.Companion.withSession as transactionContextWithSession
 
@@ -20,7 +20,7 @@ open class PostgresSessionContext(
     private val sessionCounter: SessionCounter,
 ) : SessionContext {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = KotlinLogging.logger {}
 
     // Det er viktig at sesjoner ikke opprettes utenfor en try-with-resource, som kan føre til connection-lekkasjer.
     private var session: Session? = null
@@ -84,7 +84,7 @@ open class PostgresSessionContext(
     override fun isClosed(): Boolean {
         if (session == null) return true
         return Either.catch { session!!.connection.underlying.isClosed }.getOrElse {
-            log.error("En feil skjedde når vi prøvde å sjekke om sesjonen var lukket", it)
+            log.error(it) { "En feil skjedde når vi prøvde å sjekke om sesjonen var lukket" }
             true
         }
     }

--- a/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresTransactionContext.kt
+++ b/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresTransactionContext.kt
@@ -2,13 +2,13 @@ package no.nav.tiltakspenger.libs.persistering.infrastruktur
 
 import arrow.core.Either
 import arrow.core.getOrElse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Session
 import kotliquery.TransactionalSession
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
-import org.slf4j.LoggerFactory
 import javax.sql.DataSource
 
 /**
@@ -21,7 +21,7 @@ class PostgresTransactionContext(
     private val sessionCounter: SessionCounter,
 ) : TransactionContext {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = KotlinLogging.logger {}
 
     // Det er viktig at sesjoner ikke opprettes utenfor en try-with-resource, som kan føre til connection-lekkasjer.
     private var transactionalSession: TransactionalSession? = null
@@ -100,7 +100,7 @@ class PostgresTransactionContext(
     override fun isClosed(): Boolean {
         if (transactionalSession == null) return true
         return Either.catch { transactionalSession!!.connection.underlying.isClosed }.getOrElse {
-            log.error("En feil skjedde når vi prøvde å sjekke om den den transaksjonelle sesjonen var lukket", it)
+            log.error(it) { "En feil skjedde når vi prøvde å sjekke om den den transaksjonelle sesjonen var lukket" }
             true
         }
     }

--- a/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/SessionCounter.kt
+++ b/persistering/persistering-infrastruktur/main/no/nav/tiltakspenger/libs/persistering/infrastruktur/SessionCounter.kt
@@ -1,15 +1,12 @@
 package no.nav.tiltakspenger.libs.persistering.infrastruktur
 
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import kotlin.concurrent.getOrSet
 
 class SessionCounter(
     private val logger: KLogger,
     private val whenOverThreshold: (numberOfSession: Int) -> Unit = {
-        logger.error(
-            "Sessions per thread over threshold: We started a new session while a session for this thread was already open. Total number of session: $it.",
-            RuntimeException("Genererer en stacktrace for enklere debugging."),
-        )
+        logger.error(RuntimeException("Genererer en stacktrace for enklere debugging.")) { "Sessions per thread over threshold: We started a new session while a session for this thread was already open. Total number of session: $it." }
     },
 ) {
     private val activeSessionsPerThread: ThreadLocal<Int> = ThreadLocal()

--- a/persistering/persistering-infrastruktur/test/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresTransactionContextTest.kt
+++ b/persistering/persistering-infrastruktur/test/no/nav/tiltakspenger/libs/persistering/infrastruktur/PostgresTransactionContextTest.kt
@@ -1,10 +1,10 @@
 package no.nav.tiltakspenger.libs.persistering.infrastruktur
 
 import arrow.core.Either
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionContext.Companion.withSession
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresTransactionContext.Companion.withSession
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresTransactionContext.Companion.withTransaction

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklient.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import arrow.core.flatten
 import arrow.core.left
 import com.fasterxml.jackson.module.kotlin.readValue
-import mu.KLogger
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.json.objectMapper

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesPersonklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesPersonklient.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.libs.personklient.pdl
 
 import arrow.core.Either
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import kotlin.time.Duration

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesAdressebeskyttelseKlient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesAdressebeskyttelseKlient.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.libs.personklient.pdl.adressebeskyttelse
 
 import arrow.core.Either
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.person.AdressebeskyttelseGradering

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpAdressebeskyttelseKlient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpAdressebeskyttelseKlient.kt
@@ -4,11 +4,11 @@ import arrow.core.Either
 import arrow.core.flatten
 import arrow.core.left
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
-import mu.KLogger
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.json.objectMapper

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/skjerming/FellesHttpSkjermingsklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/skjerming/FellesHttpSkjermingsklient.kt
@@ -5,11 +5,11 @@ import arrow.core.NonEmptyList
 import arrow.core.flatten
 import arrow.core.left
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
-import mu.KLogger
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.Fnr

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/skjerming/FellesSkjermingsklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/skjerming/FellesSkjermingsklient.kt
@@ -2,7 +2,7 @@ package no.nav.tiltakspenger.libs.personklient.skjerming
 
 import arrow.core.Either
 import arrow.core.NonEmptyList
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.Fnr

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/tilgangsstyring/TilgangsstyringServiceImpl.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/tilgangsstyring/TilgangsstyringServiceImpl.kt
@@ -5,11 +5,11 @@ import arrow.core.NonEmptyList
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import mu.KLogger
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.Fnr

--- a/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklientTest.kt
+++ b/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklientTest.kt
@@ -4,11 +4,11 @@ import arrow.core.left
 import com.marcinziolo.kotlin.wiremock.equalTo
 import com.marcinziolo.kotlin.wiremock.post
 import com.marcinziolo.kotlin.wiremock.returns
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import kotlinx.coroutines.test.runTest
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.random

--- a/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpPersonTilgangsstyringKlientTest.kt
+++ b/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpPersonTilgangsstyringKlientTest.kt
@@ -7,6 +7,7 @@ import com.marcinziolo.kotlin.wiremock.equalTo
 import com.marcinziolo.kotlin.wiremock.fixedMs
 import com.marcinziolo.kotlin.wiremock.post
 import com.marcinziolo.kotlin.wiremock.returns
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.assertions.fail
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.shouldBe
@@ -16,7 +17,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.person.AdressebeskyttelseGradering.STRENGT_FORTROLIG


### PR DESCRIPTION
## Beskrivelse
Oppgraderer kotlinlogging. Fikser samtidig de stedene der vi brukte parenteser og sendte inn exceptions på mer tradisjonell måte så det skal fungere bedre med kotlinlogging. 

## Kommentarer
https://trello.com/c/Jwn5QTbQ/1187-oppdater-kotlin-logging-fra-3-til-7
