### PR TITLE
noen topics bruker fnr som key og da bør vi la være å logge key

### DIFF
--- a/kafka/test/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumerTest.kt
+++ b/kafka/test/no/nav/tiltakspenger/libs/kafka/ManagedKafkaConsumerTest.kt
@@ -47,7 +47,7 @@ class ManagedKafkaConsumerTest {
 
         produceStringString(ProducerRecord(topic, key, value))
 
-        val consumer = ManagedKafkaConsumer(topic, stringConsumerConfig) { k: String, v: String ->
+        val consumer = ManagedKafkaConsumer(topic = topic, config = stringConsumerConfig) { k: String, v: String ->
             cache[k] = v
         }
         consumer.run()
@@ -74,7 +74,7 @@ class ManagedKafkaConsumerTest {
                 groupId = "test-consumer-${UUID.randomUUID()}",
             )
 
-        val consumer = ManagedKafkaConsumer(uuidTopic, config) { k: UUID, v: ByteArray ->
+        val consumer = ManagedKafkaConsumer(topic = uuidTopic, config = config) { k: UUID, v: ByteArray ->
             cache[k] = v
         }
         consumer.run()
@@ -94,7 +94,7 @@ class ManagedKafkaConsumerTest {
 
         produceStringString(ProducerRecord(topic, key, value))
 
-        val consumer = ManagedKafkaConsumer<String, String>(topic, stringConsumerConfig) { _, _ ->
+        val consumer = ManagedKafkaConsumer<String, String>(topic = topic, config = stringConsumerConfig) { _, _ ->
             antallGangerKallt++
             error("skal feile noen ganger")
         }
@@ -119,7 +119,7 @@ class ManagedKafkaConsumerTest {
         val consumed = mutableListOf<Int>()
         val failures = mutableListOf(7, 42, 42, 93)
 
-        val consumer = ManagedKafkaConsumer<Int, Int>(intTopic.name(), intConsumerConfig) { k, _ ->
+        val consumer = ManagedKafkaConsumer<Int, Int>(topic = intTopic.name(), config = intConsumerConfig) { k, _ ->
             if (k in failures) {
                 failures.remove(k)
                 error("Skal feile på $k")
@@ -155,7 +155,7 @@ class ManagedKafkaConsumerTest {
 
         val consumed = mutableMapOf<Int, Int>()
         val failures = mutableListOf(7, 42, 42)
-        val consumer = ManagedKafkaConsumer<Int, Int>(intTopic.name(), intConsumerConfig) { k, v ->
+        val consumer = ManagedKafkaConsumer<Int, Int>(topic = intTopic.name(), config = intConsumerConfig) { k, v ->
             if (k in failures) {
                 failures.remove(k)
                 error("Skal feile på $k")


### PR DESCRIPTION
## Beskrivelse
PDL bruker fnr som key og det vil vi ikke ha i vanlig logg

## Kommentarer
https://trello.com/c/gDaBF3Ps/1421-lytte-p%C3%A5-leesah-topic-og-opprette-oppgave-i-gosys-hvis-bruker-som-mottar-tiltakspenger-d%C3%B8r-eller-f%C3%A5r-barn
