### PR TITLE
1477 cacher oppslag på adressebeskyttelse

### DIFF
--- a/personklient/personklient-infrastruktur/build.gradle.kts
+++ b/personklient/personklient-infrastruktur/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.0")
+
     testImplementation(project(":test-common"))
 }
 

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpAdressebeskyttelseKlient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/adressebeskyttelse/FellesHttpAdressebeskyttelseKlient.kt
@@ -37,7 +37,7 @@ internal class FellesHttpAdressebeskyttelseKlient(
     private val logg: KLogger? = KotlinLogging.logger {},
     private val sikkerlogg: KLogger?,
 ) : FellesAdressebeskyttelseKlient {
-    private val cache: Cache<Fnr, List<AdressebeskyttelseGradering>> = Caffeine.newBuilder()
+    private val cache: Cache<String, List<AdressebeskyttelseGradering>> = Caffeine.newBuilder()
         .expireAfterWrite(java.time.Duration.ofMinutes(60))
         .build()
 
@@ -51,12 +51,12 @@ internal class FellesHttpAdressebeskyttelseKlient(
     override suspend fun enkel(
         fnr: Fnr,
     ): Either<FellesAdressebeskyttelseError, List<AdressebeskyttelseGradering>?> {
-        cache.getIfPresent(fnr)?.let {
+        cache.getIfPresent(fnr.verdi)?.let {
             return it.right()
         }
         return bolk(listOf(fnr)).map {
             val adressebeskyttelse = it[fnr]
-            adressebeskyttelse?.let { v -> cache.put(fnr, v) }
+            adressebeskyttelse?.let { v -> cache.put(fnr.verdi, v) }
             return@map adressebeskyttelse
         }
     }


### PR DESCRIPTION
https://trello.com/c/qQ7idKtU/1078-sende-statistikk-n%C3%A5r-vi-sender-f%C3%B8rstegangsvedtak-til-beslutter vil trigge en del ekstra kall for å sjekke adressebeskyttelse. For at vi ikke skal gjøre så mange oppslag legger vi til caching. 

https://trello.com/c/tYBleeK5/1477-legg-til-caching-av-oppslag-p%C3%A5-adressebeskyttelse-og-tilgangskontroll-i-klient-i-libs