### PR TITLE
1406 sender inn attributes for å unngå feil hvis appen er stoppet

### DIFF
--- a/jobber/build.gradle.kts
+++ b/jobber/build.gradle.kts
@@ -1,3 +1,5 @@
+val ktorVersion = "3.1.3"
+
 dependencies {
     implementation(project(":common"))
     implementation(project(":logging"))
@@ -5,6 +7,8 @@ dependencies {
 
     implementation("io.arrow-kt:arrow-core:2.1.1")
     implementation("org.jetbrains.kotlinx:atomicfu:0.27.0")
+
+    implementation("io.ktor:ktor-utils:$ktorVersion")
 
     testImplementation(project(":test-common"))
 }

--- a/jobber/main/no/nav/tiltakspenger/libs/jobber/RunJobCheck.kt
+++ b/jobber/main/no/nav/tiltakspenger/libs/jobber/RunJobCheck.kt
@@ -1,17 +1,20 @@
 package no.nav.tiltakspenger.libs.jobber
 
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
 import java.net.InetAddress
 
 data class RunCheckFactory(
     private val leaderPodLookup: LeaderPodLookup,
-    private val applicationIsReady: () -> Boolean,
+    private val attributes: Attributes,
+    private val isReadyKey: AttributeKey<Boolean>,
 ) {
     fun leaderPod(): LeaderPod {
         return LeaderPod(leaderPodLookup = leaderPodLookup)
     }
 
     fun isReady(): IsReady {
-        return IsReady { applicationIsReady() }
+        return IsReady(attributes = attributes, isReadyKey = isReadyKey)
     }
 }
 
@@ -32,9 +35,10 @@ data class LeaderPod(
 }
 
 data class IsReady(
-    private val applicationIsReady: () -> Boolean,
+    private val attributes: Attributes,
+    private val isReadyKey: AttributeKey<Boolean>,
 ) : RunJobCheck {
     override fun shouldRun(): Boolean {
-        return applicationIsReady()
+        return attributes.getOrNull(isReadyKey) == true
     }
 }

--- a/jobber/test/no/nav/tiltakspenger/libs/jobber/RunCheckFactoryTest.kt
+++ b/jobber/test/no/nav/tiltakspenger/libs/jobber/RunCheckFactoryTest.kt
@@ -3,18 +3,23 @@ package no.nav.tiltakspenger.libs.jobber
 import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 
 internal class RunCheckFactoryTest {
+    private val isReadyKey = AttributeKey<Boolean>("isReady")
+    private val attributes = Attributes()
+
     @Test
     fun `leaderpod - false`() {
         val mock = mockk<LeaderPodLookup> {
             coEvery { amITheLeader(any()) } returns false.right()
         }
-        RunCheckFactory(leaderPodLookup = mock) { isReady() }.let {
+        RunCheckFactory(leaderPodLookup = mock, attributes = attributes, isReadyKey = isReadyKey).let {
             it.leaderPod().shouldRun() shouldBe false
             coVerify(exactly = 1) { mock.amITheLeader(any()) }
         }
@@ -25,7 +30,7 @@ internal class RunCheckFactoryTest {
         val mock = mockk<LeaderPodLookup> {
             coEvery { amITheLeader(any()) } returns true.right()
         }
-        RunCheckFactory(leaderPodLookup = mock) { isReady() }.let {
+        RunCheckFactory(leaderPodLookup = mock, attributes = attributes, isReadyKey = isReadyKey).let {
             it.leaderPod().shouldRun() shouldBe true
             coVerify(exactly = 1) { mock.amITheLeader(any()) }
         }
@@ -36,7 +41,7 @@ internal class RunCheckFactoryTest {
         val mock = mockk<LeaderPodLookup> {
             coEvery { amITheLeader(any()) } returns LeaderPodLookupFeil.Ikke2xx(500, "").left()
         }
-        RunCheckFactory(leaderPodLookup = mock) { isReady() }.let {
+        RunCheckFactory(leaderPodLookup = mock, attributes = attributes, isReadyKey = isReadyKey).let {
             it.leaderPod().shouldRun() shouldBe false
             coVerify(exactly = 1) { mock.amITheLeader(any()) }
         }
@@ -45,20 +50,16 @@ internal class RunCheckFactoryTest {
     @Test
     fun `isready - false`() {
         val mock = mockk<LeaderPodLookup>()
-        RunCheckFactory(leaderPodLookup = mock) { isNotReady() }
+        attributes.put(isReadyKey, false)
+        RunCheckFactory(leaderPodLookup = mock, attributes = attributes, isReadyKey = isReadyKey)
             .isReady().shouldRun() shouldBe false
     }
 
     @Test
     fun `isready - true`() {
         val mock = mockk<LeaderPodLookup>()
-        RunCheckFactory(leaderPodLookup = mock) { isReady() }
+        attributes.put(isReadyKey, true)
+        RunCheckFactory(leaderPodLookup = mock, attributes = attributes, isReadyKey = isReadyKey)
             .isReady().shouldRun() shouldBe true
     }
-
-    private fun isReady(): Boolean =
-        true
-
-    private fun isNotReady(): Boolean =
-        false
 }


### PR DESCRIPTION
Hvis appen er stoppet får vi feilmelding når vi har sendt inn hele funksjonen og forsøker å kalle den. Hypotesen er at det ikke vil skje hvis vi sender inn attributes og keyen siden sjekken da kan gjøres uavhengig av om vi har en kjørende Application eller ikke. 

https://trello.com/c/j9Ozj5P1/1406-tidvis-exception-fra-jobbene-n%C3%A5r-vi-stanser-applikasjonen