### PR TITLE
1215 legger til mapping til saksbehandler/systembruker og hjelpemetod…

### DIFF
--- a/texas/build.gradle.kts
+++ b/texas/build.gradle.kts
@@ -8,7 +8,10 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
     implementation("io.ktor:ktor-server-auth:$ktorVersion")
+    implementation("io.arrow-kt:arrow-core:2.1.2")
     implementation(project(":logging"))
     implementation(project(":common"))
     implementation(project(":json"))
+    implementation(project(":ktor-common"))
+    implementation(project(":auth-core"))
 }

--- a/texas/main/no/nav/tiltakspenger/libs/texas/ApplicationCallHelpers.kt
+++ b/texas/main/no/nav/tiltakspenger/libs/texas/ApplicationCallHelpers.kt
@@ -1,0 +1,90 @@
+package no.nav.tiltakspenger.libs.texas
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.principal
+import no.nav.tiltakspenger.libs.auth.core.AdRolle
+import no.nav.tiltakspenger.libs.common.GenerellSystembruker
+import no.nav.tiltakspenger.libs.common.GenerellSystembrukerrolle
+import no.nav.tiltakspenger.libs.common.GenerellSystembrukerroller
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
+import no.nav.tiltakspenger.libs.ktor.common.respond500InternalServerError
+
+suspend fun ApplicationCall.saksbehandler(
+    autoriserteBrukerroller: List<AdRolle>,
+    systembrukerMapper: (klientId: String, klientnavn: String, roller: Set<String>) -> GenerellSystembruker<
+        GenerellSystembrukerrolle,
+        GenerellSystembrukerroller<GenerellSystembrukerrolle>,
+        >,
+): Saksbehandler? {
+    val principal = principal<TexasPrincipalInternal>() ?: throw IllegalStateException("Mangler principal")
+
+    principal.toSaksbehandler(autoriserteBrukerroller, systembrukerMapper).fold(
+        ifLeft = {
+            when (it) {
+                is InternalPrincipalMappingfeil.IkkeSaksbehandler -> this.respond403Forbidden(
+                    melding = "Brukeren er ikke en saksbehandler",
+                    kode = "ikke_saksbehandler",
+                )
+
+                is InternalPrincipalMappingfeil.IngenRoller -> this.respond403Forbidden(
+                    melding = "Saksbehandler må ha minst en autorisert rolle for å aksessere denne ressursen",
+                    kode = "mangler_rolle",
+                )
+
+                is InternalPrincipalMappingfeil.ManglerClaim -> this.respond403Forbidden(
+                    melding = "Tokenet mangler claim: ${it.claim}",
+                    kode = "ugyldig_token",
+                )
+
+                else -> this.respond500InternalServerError(
+                    melding = "Noe gikk galt ved mapping til saksbehandler",
+                    kode = "ukjent_feil",
+                )
+            }
+            return null
+        },
+        ifRight = {
+            return it
+        },
+    )
+}
+
+suspend fun ApplicationCall.systembruker(
+    systembrukerMapper: (klientId: String, klientnavn: String, roller: Set<String>) -> GenerellSystembruker<
+        GenerellSystembrukerrolle,
+        GenerellSystembrukerroller<GenerellSystembrukerrolle>,
+        >,
+): GenerellSystembruker<*, *>? {
+    val principal = principal<TexasPrincipalInternal>() ?: throw IllegalStateException("Mangler principal")
+
+    principal.toSystembruker(systembrukerMapper).fold(
+        ifLeft = {
+            when (it) {
+                is InternalPrincipalMappingfeil.IkkeSystembruker -> this.respond403Forbidden(
+                    melding = "Brukeren er ikke en systembruker",
+                    kode = "ikke_systembruker",
+                )
+
+                is InternalPrincipalMappingfeil.IngenRoller -> this.respond403Forbidden(
+                    melding = "Systembrukeren må ha minst en autorisert rolle for å aksessere denne ressursen",
+                    kode = "mangler_rolle",
+                )
+
+                is InternalPrincipalMappingfeil.ManglerClaim -> this.respond403Forbidden(
+                    melding = "Tokenet mangler claim: ${it.claim}",
+                    kode = "ugyldig_token",
+                )
+
+                else -> this.respond500InternalServerError(
+                    melding = "Noe gikk galt ved mapping til saksbehandler",
+                    kode = "ukjent_feil",
+                )
+            }
+            return null
+        },
+        ifRight = {
+            return it
+        },
+    )
+}

--- a/texas/main/no/nav/tiltakspenger/libs/texas/ApplicationCallHelpers.kt
+++ b/texas/main/no/nav/tiltakspenger/libs/texas/ApplicationCallHelpers.kt
@@ -3,12 +3,18 @@ package no.nav.tiltakspenger.libs.texas
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.principal
 import no.nav.tiltakspenger.libs.auth.core.AdRolle
+import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.GenerellSystembruker
 import no.nav.tiltakspenger.libs.common.GenerellSystembrukerrolle
 import no.nav.tiltakspenger.libs.common.GenerellSystembrukerroller
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
 import no.nav.tiltakspenger.libs.ktor.common.respond500InternalServerError
+
+fun ApplicationCall.fnr(): Fnr {
+    val principal = principal<TexasPrincipalExternalUser>() ?: throw IllegalStateException("Mangler principal")
+    return principal.fnr
+}
 
 suspend fun ApplicationCall.saksbehandler(
     autoriserteBrukerroller: List<AdRolle>,

--- a/texas/main/no/nav/tiltakspenger/libs/texas/TexasPrincipalExternalUser.kt
+++ b/texas/main/no/nav/tiltakspenger/libs/texas/TexasPrincipalExternalUser.kt
@@ -1,0 +1,16 @@
+package no.nav.tiltakspenger.libs.texas
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.principal
+import no.nav.tiltakspenger.libs.common.Fnr
+
+data class TexasPrincipalExternalUser(
+    val claims: Map<String, Any?>,
+    val token: String,
+    val fnr: Fnr,
+)
+
+fun ApplicationCall.fnr(): Fnr {
+    val principal = principal<TexasPrincipalExternalUser>() ?: throw IllegalStateException("Mangler principal")
+    return principal.fnr
+}

--- a/texas/main/no/nav/tiltakspenger/libs/texas/TexasPrincipalExternalUser.kt
+++ b/texas/main/no/nav/tiltakspenger/libs/texas/TexasPrincipalExternalUser.kt
@@ -1,7 +1,5 @@
 package no.nav.tiltakspenger.libs.texas
 
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.auth.principal
 import no.nav.tiltakspenger.libs.common.Fnr
 
 data class TexasPrincipalExternalUser(
@@ -9,8 +7,3 @@ data class TexasPrincipalExternalUser(
     val token: String,
     val fnr: Fnr,
 )
-
-fun ApplicationCall.fnr(): Fnr {
-    val principal = principal<TexasPrincipalExternalUser>() ?: throw IllegalStateException("Mangler principal")
-    return principal.fnr
-}


### PR DESCRIPTION
…er for å hente dette fra principal

saksbehandling-api bruker en del hjelpefunksjoner for å validere og hente ut saksbehandler-objekt/systembruker-objekt fra token som ikke helt lar seg overføre med texas. Jeg vil forsøke å holde tokenvalideringen og mappingen adskilt så det er lettere å se hva som skjer og så det skal bli mer i tråd med hvordan de andre appene våre er satt opp, samtidig som det skal være lett å hente saksbehandler/systembruker-objekter. Og helst uten at jeg må gjøre altfor drastiske endringer i saksbehandling-api 😅 Så da blir dette første forsøk, så kan det hende jeg må endre litt etterhvert som jeg forsøker å få det inn i saksbehandling-api. 

Renamen fra TexasPrincipalUser vil brekke litt i søknad-api, men jeg tror det nye navnet er bedre, så det skal jeg få oppdatert der også. 

https://trello.com/c/btZxTUxr/1215-legg-inn-texas-i-libs-s%C3%A5-vi-kan-bruke-det-i-andre-applikasjoner-ogs%C3%A5