### PR TITLE
1343 Fjerner fnr fra metodesignaturen da dette er noe som er bakt inn i GraphQL-requestobjektet

### DIFF
--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklient.kt
@@ -37,8 +37,7 @@ internal class FellesHttpPersonklient(
 
     private val uri = URI.create(endepunkt)
 
-    override suspend fun hentPerson(
-        fnr: Fnr,
+    fun doGraphQLRequest(
         token: AccessToken,
         jsonRequestBody: String,
     ): Either<FellesPersonklientError, String> {
@@ -90,6 +89,21 @@ internal class FellesHttpPersonklient(
             Sikkerlogg.error(it) { "Ukjent feil ved henting av person fra PDL. request: $jsonRequestBody" }
             FellesPersonklientError.NetworkError(it)
         }.flatten()
+    }
+
+    override suspend fun hentPerson(
+        fnr: Fnr,
+        token: AccessToken,
+        jsonRequestBody: String,
+    ): Either<FellesPersonklientError, String> {
+        return doGraphQLRequest(token, jsonRequestBody)
+    }
+
+    override suspend fun graphqlRequest(
+        token: AccessToken,
+        jsonRequestBody: String,
+    ): Either<FellesPersonklientError, String> {
+        return doGraphQLRequest(token, jsonRequestBody)
     }
 }
 

--- a/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesPersonklient.kt
+++ b/personklient/personklient-infrastruktur/main/no/nav/tiltakspenger/libs/personklient/pdl/FellesPersonklient.kt
@@ -8,8 +8,14 @@ import kotlin.time.Duration.Companion.seconds
 
 interface FellesPersonklient {
 
+    @Deprecated("Bruk graphqlRequest() istedenfor. Hvorvidt requesten er en hentPerson eller annen query bestemmes av jsonRequestBody. Dermed er det unødvendig at ident/fnr er en egen parameter her.")
     suspend fun hentPerson(
         fnr: Fnr,
+        token: AccessToken,
+        jsonRequestBody: String,
+    ): Either<FellesPersonklientError, String>
+
+    suspend fun graphqlRequest(
         token: AccessToken,
         jsonRequestBody: String,
     ): Either<FellesPersonklientError, String>

--- a/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklientTest.kt
+++ b/personklient/personklient-infrastruktur/test/no/nav/tiltakspenger/libs/personklient/pdl/FellesHttpPersonklientTest.kt
@@ -9,8 +9,6 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import kotlinx.coroutines.test.runTest
 import no.nav.tiltakspenger.libs.common.AccessToken
-import no.nav.tiltakspenger.libs.common.Fnr
-import no.nav.tiltakspenger.libs.common.random
 import no.nav.tiltakspenger.libs.personklient.pdl.FellesPersonklientError.DeserializationException
 import no.nav.tiltakspenger.libs.personklient.pdl.FellesPersonklientError.UkjentFeil
 import no.nav.tiltakspenger.libs.personklient.pdl.common.withWireMockServer
@@ -38,7 +36,7 @@ internal class FellesHttpPersonklientTest {
                 connectTimeout = 100.milliseconds,
             )
             runTest {
-                pdlClient.hentPerson(Fnr.random(), token, "{}").getOrNull()!!
+                pdlClient.doGraphQLRequest(token, "{}").getOrNull()!!
             }
         }
     }
@@ -58,7 +56,7 @@ internal class FellesHttpPersonklientTest {
                 connectTimeout = 100.milliseconds,
             )
             runTest {
-                pdlClient.hentPerson(Fnr.random(), token, "body").swap().getOrNull()!! shouldBe UkjentFeil(
+                pdlClient.graphqlRequest(token, "body").swap().getOrNull()!! shouldBe UkjentFeil(
                     errors = listOf(
                         PdlError(
                             message = "Validation error of type FieldUndefined: Field 'rettIdentitetErUkjentadsa' in type 'FalskIdentitet' is undefined @ 'hentPerson/falskIdentitet/rettIdentitetErUkjentadsa'",
@@ -89,7 +87,7 @@ internal class FellesHttpPersonklientTest {
                 connectTimeout = 100.milliseconds,
             )
             runTest {
-                pdlClient.hentPerson(Fnr.random(), token, "body") shouldBe FellesPersonklientError.ResponsManglerData.left()
+                pdlClient.graphqlRequest(token, "body") shouldBe FellesPersonklientError.ResponsManglerData.left()
             }
         }
     }
@@ -111,7 +109,7 @@ internal class FellesHttpPersonklientTest {
                 connectTimeout = 100.milliseconds,
             )
             runTest {
-                pdlClient.hentPerson(Fnr.random(), token, "body").swap().getOrNull()!!.also {
+                pdlClient.graphqlRequest(token, "body").swap().getOrNull()!!.also {
                     it.shouldBeTypeOf<DeserializationException>()
                     it.exception.shouldBeTypeOf<com.fasterxml.jackson.core.JsonParseException>()
                     it.exception.message shouldContain "Unrecognized token 'asd'"
@@ -135,7 +133,7 @@ internal class FellesHttpPersonklientTest {
                 connectTimeout = 100.milliseconds,
             )
             runTest {
-                pdlClient.hentPerson(Fnr.random(), token, "body").getOrNull()!!
+                pdlClient.graphqlRequest(token, "body").getOrNull()!!
             }
         }
     }


### PR DESCRIPTION
Parameteren ble ikke brukt til noe uansett, men metodesignaturen gjør at det blir tungvint å støtte bolkoppslag hvor man skal kunne sende inn en liste med identer