### PR TITLE
Legg til standardisert http-klient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@ Dette repoet følger monorepo-konvensjonene i [`../AGENTS.md`](../AGENTS.md) og 
 
 ## Oversikt
 
-Monorepo for delte Kotlin-biblioteker. Publiseres til GitHub Packages. **Deployes ikke til NAIS.** Brukes av `tiltakspenger-saksbehandling-api`, `tiltakspenger-soknad-api`, `tiltakspenger-meldekort-api`, `tiltakspenger-datadeling`, `tiltakspenger-tiltak` med flere.
+Monorepo for delte Kotlin-biblioteker.
+Publiseres til GitHub Packages.
+**Deployes ikke til NAIS.**
+Brukes av `tiltakspenger-saksbehandling-api`, `tiltakspenger-soknad-api`, `tiltakspenger-meldekort-api`, `tiltakspenger-datadeling`, `tiltakspenger-tiltak` med flere.
 
 ## Arkitektur
 
@@ -23,11 +26,45 @@ Monorepo for delte Kotlin-biblioteker. Publiseres til GitHub Packages. **Deploye
 | `periodisering` | Periodelogikk for datoer (`Periode`, `Periodisering`, `Tidslinje`)                                                                        |
 | `json`          | Delt Jackson-`objectMapper` + hjelperne `serialize()`/`deserialize()`                                                                     |
 | `logging`       | `Sikkerlogg` for NAIS secure logging via markers                                                                                          |
-| `test-common`   | Delt test-infra: `fixedClock`, `TikkendeKlokke`, `getOrFail()` for `Either`, wiremock-hjelpere                                            |
+| `httpklient`    | Delt `java.net.http.HttpClient`-innpakning med `HttpKlient`, Arrow `Either`-feil, JSON-hjelpere, valgfri bearer-token-støtte via `AccessToken`, valgfri retry basert på Arrow Resilience `Schedule` (standard predikat for idempotente metoder, per-forsøk-timing i metadata, hook for overdreven retry), og valgfri circuit breaker basert på Arrow Resilience `CircuitBreaker` |
+| `test-common`   | Delt test-infra: `fixedClock`, `TikkendeKlokke`, `getOrFail()` for `Either`, `HttpKlientFake`, wiremock-hjelpere                          |
 | `texas`         | NAIS Texas auth: token-introspeksjon, system-tokens, Ktor auth provider                                                                   |
 | `ktor-common`   | Ktor-server-extensions (bruker `compileOnly` for ktor-deps)                                                                               |
 | `jobber`        | Leader election + stoppable job-abstraksjoner for NAIS                                                                                    |
 | `*-dtos`        | API-kontraktstyper delt mellom tjenester                                                                                                  |
+
+## Konvensjoner
+
+### KDoc og kommentarer
+
+Skriv **én setning per linje** i KDoc og kommentarer — ikke bryt én setning over flere linjer, og ikke slå flere setninger sammen på én linje.
+Dette gir renere differ (en endret setning berører kun én linje) og er enklere å lese, søke i og vedlikeholde.
+Maks linjelengde er bevisst slått av i ktlint-konfigurasjonen, så en lang setning skal stå på én linje selv om den blir bred.
+
+### `httpklient`-struktur
+
+Den offentlige klientkontrakten er `HttpKlient`.
+Konsumenter oppretter en klient via `HttpKlient(clock = ...) { ... }`-fabrikken, som konfigurerer og returnerer den interne `JavaHttpKlient`-implementasjonen (basert på `java.net.http.HttpClient`).
+Implementasjonstypen er bevisst `internal` slik at kallere kun avhenger av interfacet.
+Alle standardverdier — connect/timeout, predikat for vellykkede statuser, logging, retry, circuit breaker, auth-token-leverandør — settes via `HttpKlient.HttpKlientConfig`-DSL-en som sendes til fabrikken; per-request-overstyringer på `RequestBuilder` har prioritet.
+Tester utenfor `httpklient`-modulen skal generelt bruke `HttpKlientFake` fra `test-common`; tester inne i `httpklient` skal teste den virkelige implementasjonen mot WireMock/rå sockets der det er praktisk.
+
+Retry-relaterte typer ligger i pakka `no.nav.tiltakspenger.libs.httpklient.retry` (kildefiler under `httpklient/src/main/kotlin/httpklient/retry/`) for å holde retry-logikk nær `RetryConfig` og adskilt fra `JavaHttpKlient` — pakkenavnet følger mappestrukturen.
+Circuit breaker-relaterte typer ligger tilsvarende i `no.nav.tiltakspenger.libs.httpklient.circuitbreaker` (under `httpklient/src/main/kotlin/httpklient/circuitbreaker/`).
+`CircuitBreakerConfig.None` er standard; aktiverte konfigurasjoner er opt-in, fluent, eksplisitt navngitte, støttet av Arrow Resilience `CircuitBreaker`, og tilstand er lokal per `HttpKlient`-instans per circuit breaker-navn.
+Circuit breaker-beskyttelse omslutter hele retry-kjøringen, slik at kun det endelige resultatet etter retries registreres.
+
+### Ingen standardverdier i domenetyper eller offentlige API-er
+
+Standardverdier hører hjemme i **konfig-/builder-objekter** (f.eks. `HttpKlientLoggingConfig`, `RetryConfig`), **ikke** i databærere, domenemodeller eller konstruktørparametere som beskriver hva som faktisk skjedde eller hvem kalleren er.
+Konkret:
+
+- **Dataoppføringer som beskriver en hendelse/et resultat** (f.eks. `HttpKlientMetadata` — request/respons, antall forsøk, tidsbruk) må kreve alle felt eksplisitt. Standardverdier som `attempts = 1` eller `attemptDurations = emptyList()` skjuler feil der produsenten glemte å fylle ut feltet.
+- **`Clock`-parametere** må være påkrevd i produksjonskode. Bruk aldri `Clock.systemUTC()` som standard i `main/`. Tester kan som regel bruke `fixedClock` eller `TikkendeKlokke` fra `test-common` som standard — nesten aldri `Clock.systemUTC()`.
+- **Andre «ambient»-tjenester** (loggere, ID-generatorer, tilfeldighetskilder osv.) følger samme regel: påkrevd i produksjon, fornuftig teststandard i `test-common`.
+- **Testhjelpere** som lager domene-verdier (f.eks. `tomMetadata()` i `httpklient`-testene) må fylle alle felt eksplisitt slik at testflaten er søkbar når typen endres.
+
+Hvis du finner deg selv i å legge til en standardverdi for å få ødelagte/manglende kallsteder til å kompilere, **fiks kallstedene i stedet** — standardverdien skjuler problemet.
 
 ## Bygg og test (libs-spesifikt)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ wiremock = "3.13.2"
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-core-jackson = { module = "io.arrow-kt:arrow-core-jackson", version.ref = "arrow" }
+arrow-resilience = { module = "io.arrow-kt:arrow-resilience", version.ref = "arrow" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 auth0-java-jwt = { module = "com.auth0:java-jwt", version.ref = "auth0-jwt" }
 auth0-jwks-rsa = { module = "com.auth0:jwks-rsa", version.ref = "auth0-jwks" }

--- a/httpklient/README.md
+++ b/httpklient/README.md
@@ -1,0 +1,385 @@
+# httpklient
+
+`httpklient` er en liten felles HTTP-klient basert på Java sin innebygde `java.net.http.HttpClient`.
+
+Målet er å standardisere enkel HTTP-bruk i tiltakspenger-libs med:
+
+- Arrow `Either<HttpKlientError, HttpKlientResponse<T>>` i stedet for exceptions i API-et (suksess-grenen er en `HttpKlientResponse<T>` med status, body og metadata).
+- Egne venstresider for blant annet `Timeout`, `NetworkError`, `InvalidRequest`, `UventetStatus`, `SerializationError`, `DeserializationError` og `CircuitBreakerOpen`, gruppert i `RequestIkkeSendt`, `IngenRespons` og `ResponsMottatt` etter «så serveren requesten min?».
+- Støtte for JSON som `String` inn/ut.
+- Støtte for DTO-er inn/ut via `tiltakspenger-libs/json` sine `serialize`/`deserialize`-hjelpere.
+- Suspend-first API med en Ktor-inspirert `RequestBuilder`.
+- Verb-hjelpere for `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD` og `OPTIONS`.
+- Felles `HttpKlientMetadata` på både `HttpKlientResponse` og `HttpKlientError` med rå request/response, headere og status der de finnes.
+- Konfigurerbar definisjon av hvilke HTTP-statuser som regnes som suksess.
+- Valgfri resilience via retry og circuit breaker basert på Arrow Resilience.
+- Valgfri logging via vanlig `KLogger` og/eller `Sikkerlogg`.
+
+## Eksempel
+
+Bruk `HttpKlient` som avhengighetstype i konsumenter.
+Produksjonsklienten opprettes via `HttpKlient(clock = ...)`-factoryen (den konkrete implementasjonen er intern).
+Tester kan bruke `HttpKlientFake` fra `test-common`.
+
+Generisk request med builder:
+
+```kotlin
+val klient: HttpKlient = HttpKlient(clock = clock)
+
+val response: Either<HttpKlientError, HttpKlientResponse<MinResponseDto>> = klient.request<MinResponseDto>(
+    uri = URI.create("https://example.com/api"),
+    method = HttpMethod.POST,
+) {
+    header("X-Trace-Id", traceId)
+    timeout = 5.seconds
+    json(MinRequestDto(id = "123"))
+}
+```
+
+Verb-hjelpere setter HTTP-metoden for deg:
+
+```kotlin
+val response = klient.get<MinResponseDto>(URI.create("https://example.com/api/123")) {
+    header("X-Trace-Id", traceId)
+    timeout = 5.seconds
+}
+```
+
+For JSON som allerede er en `String`, bruk `String`-overloaden (strengen sendes verbatim, ikke serialisert på nytt):
+
+```kotlin
+val response = klient.post<String>(URI.create("https://example.com/api"), """{"id":"123"}""")
+```
+
+Tilsvarende finnes `post`/`put`/`patch` med en DTO som `body: Any` (serialiseres via `tiltakspenger-libs/json`).
+
+For raw tekst uten JSON-headere:
+
+```kotlin
+val response = klient.post<String>(URI.create("https://example.com/api")) {
+    header("Content-Type", "text/plain")
+    body("hei")
+}
+```
+
+For `application/x-www-form-urlencoded` (f.eks. token-endepunkter):
+
+```kotlin
+val response = klient.post<String>(URI.create("https://example.com/token")) {
+    formUrlEncoded("grant_type" to "client_credentials", "scope" to "api://app-x")
+}
+```
+
+### Response-typer og tomme bodyer
+
+Response-typen `T` i `request<T>` / verb-hjelperne styrer hvordan bodyen tolkes:
+
+- `String` — rå body uten deserialisering.
+- `Unit` — bodyen ignoreres. Bruk denne for `204 No Content`, `HEAD` og andre svar uten body.
+- En DTO — bodyen deserialiseres med `tiltakspenger-libs/json`.
+
+Merk at en tom body _ikke_ kan deserialiseres til en DTO.
+Et `204`-svar, et `HEAD`-svar eller et tomt `304`-svar med en DTO som response-type gir derfor `HttpKlientError.DeserializationError`.
+Bruk `Unit` (eller `String`) som response-type for endepunkter som kan svare uten body.
+
+## Testing
+
+`test-common` eksponerer `HttpKlientFake`, en enkel fake som implementerer `HttpKlient`,
+tar opp alle requests som `HttpKlientRequest`, og svarer med køede responser/feil:
+
+```kotlin
+val httpKlient = HttpKlientFake().apply {
+    enqueueResponse(MinResponseDto(id = "123"))
+}
+
+val response = httpKlient.get<MinResponseDto>(URI.create("https://example.com/api/123")).getOrFail()
+
+httpKlient.requests.single().method shouldBe HttpMethod.GET
+```
+
+Hvis faken brukes uten konfigurert respons returneres en tydelig `HttpKlientError.InvalidRequest`
+med `metadata.attempts = 0`, slik at tester feiler deterministisk uten å finne opp en defaultverdi.
+
+## Metadata, headere og logging
+
+`HttpKlientResponse` har alltid `responseHeaders` fra HTTP-responsen og `requestHeaders` slik requesten faktisk ble sendt etter at klienten har lagt til eventuelle standard JSON-headere.
+
+Feiltypene i `HttpKlientError` har også `requestHeaders`, og `responseHeaders` når feilen kommer etter at en HTTP-respons er mottatt, for eksempel `UventetStatus` og `DeserializationError` (begge i gruppen `ResponsMottatt`, som garanterer non-null `statusCode` og rå-`body`).
+
+Både vellykkede svar og feil har i tillegg `metadata`:
+
+```kotlin
+val metadata: HttpKlientMetadata = response.metadata
+```
+
+`HttpKlientMetadata` inneholder:
+
+- `rawRequestString` — klientens tekstrepresentasjon av requesten (ikke garantert byte-for-byte wire-format fra Java `HttpClient`).
+- `rawResponseString` — rå response-body når en response finnes.
+- `requestHeaders` — effektive request-headere, med _uredigerte_ verdier (en bearer-token ligger her i klartekst). Logg derfor `rawRequestString` framfor `requestHeaders` direkte.
+- `responseHeaders` — response-headere når en response finnes.
+- `statusCode` — HTTP-status når en response finnes.
+- `attempts` — antall forsøk som ble utført, inkludert det første. `1` betyr at det ikke ble retry-et, og `0` at det aldri ble gjort et HTTP-forsøk (pre-flight-feil eller åpen circuit breaker).
+- `attemptDurations` — varighet per forsøk i den rekkefølgen de ble kjørt.
+- `totalDuration` — total veggklokketid for hele kallet (inkludert backoff mellom forsøk).
+
+Left-verdier fyller inn så mye metadata som finnes for feilsituasjonen. For eksempel har `SerializationError` request-informasjon, men ingen response, mens `UventetStatus` har både request, response-body, response-headere og status.
+
+Sensitive headere (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`) maskeres til `***` i `rawRequestString` og i logging, slik at bearer-tokens ikke lekker til logger. Selve HTTP-requesten sendes med de ekte verdiene, og det strukturerte `requestHeaders`-mappet beholder også de uredigerte verdiene (bruk `rawRequestString` hvis du skal logge).
+
+HTTP-headere er case-insensitive, så bruk hjelperne `responseHeader(name)` / `responseHeaderValues(name)` (og `requestHeader` / `requestHeaderValues`) på `HttpKlientMetadata` i stedet for å slå opp direkte i mappet:
+
+```kotlin
+val location: String? = response.metadata.responseHeader("Location")
+val cookies: List<String> = response.metadata.responseHeaderValues("Set-Cookie")
+```
+
+### Feilgruppering
+
+`HttpKlientError`-variantene er delt i tre under-grensesnitt etter spørsmålet «så serveren requesten min?». Det er denne aksen som faktisk styrer hvor trygt det er å retry-e og om kallet kan ha hatt sideeffekter:
+
+| Gruppe | Betydning | Varianter |
+|---|---|---|
+| `RequestIkkeSendt` | Ingenting ble sendt over nettverket. Serveren har garantert ikke sett requesten (`attempts = 0`). Trygt å bygge ny request og forsøke på nytt. | `InvalidRequest`, `SerializationError`, `AuthError`, `CircuitBreakerOpen` |
+| `IngenRespons` | Et HTTP-forsøk ble startet, men ingen fullstendig respons kom tilbake. Ukjent om serveren rakk å behandle requesten. | `Timeout`, `NetworkError` |
+| `ResponsMottatt` | Serveren svarte, så både `statusCode` og rå-`body` er garantert (i tillegg til `responseHeaders`). | `UventetStatus`, `DeserializationError` |
+
+Du kan matche enten på den konkrete varianten eller på gruppen. `UventetStatus` het tidligere `Ikke2xx`; navnet er endret fordi feilen egentlig betyr «status ble ikke godtatt av det konfigurerte `successStatus`-predikatet», ikke bokstavelig «utenfor 2xx».
+
+Logging er av som standard. Den kan skrus på globalt:
+
+```kotlin
+val klient = HttpKlient(clock = clock) {
+    logging = HttpKlientLoggingConfig(
+        logger = logg,
+        loggTilSikkerlogg = true,
+        inkluderHeadere = false,
+    )
+}
+```
+
+Eller per request:
+
+```kotlin
+val response = klient.get<MinResponseDto>(URI.create("https://example.com/api/123")) {
+    logging {
+        logger = logg
+        loggTilSikkerlogg = true
+        inkluderHeadere = true
+    }
+}
+```
+
+## Suksess-statuser
+
+Som standard er `2xx` suksess (`HttpStatusSuccess.is2xx`). Dette kan overstyres globalt, enten med et eget predikat eller med en av hjelperne i `HttpStatusSuccess`:
+
+```kotlin
+val klient = HttpKlient(clock = clock) {
+    successStatus = HttpStatusSuccess.exactly(200, 201, 204)
+}
+```
+
+`HttpStatusSuccess` tilbyr `is2xx`, `exactly(vararg koder)` og `inRange(range)` — så du slipper å skrive predikatene selv.
+
+Per request kan du sende inn et predikat, en liste av koder, eller en range:
+
+```kotlin
+// Eksplisitt predikat (f.eks. 2xx pluss 304)
+klient.get<String>(URI.create("https://example.com/api/cache")) {
+    successStatus { code -> HttpStatusSuccess.is2xx(code) || code == 304 }
+}
+
+// Bare noen eksakte koder
+klient.get<String>(URI.create("https://example.com/api/cache")) {
+    successStatus(200, 304)
+}
+
+// En range
+klient.get<String>(URI.create("https://example.com/api/cache")) {
+    successStatus(200..204)
+}
+```
+
+## Retry
+
+`HttpKlient` har valgfri retry-støtte basert på Arrow Resilience `Schedule`. Default er
+`RetryConfig.None`, dvs. ingen retries.
+
+Eksponentiell backoff og enkelt predikat via fabrikkmetode:
+
+```kotlin
+val klient = HttpKlient(clock = clock) {
+    defaultRetry = RetryConfig.exponential(
+        maxRetries = 3,
+        initialDelay = 200.milliseconds,
+        maxDelay = 2.seconds,
+        jitter = true,
+        retryOn = RetryOnServerErrorsAndNetwork,
+    ).notifyOnExcessiveRetries(threshold = 2)
+}
+```
+
+`RetryOnServerErrorsAndNetwork` tillater retry kun for idempotente metoder (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`).
+Hvilke utfall som i det hele tatt er retry-bare (`408`/`425`/`429`/`500`/`502`/`503`/`504` / `Timeout` / `NetworkError`) styres av `AttemptOutcome.retryable` som en hard gate før predikatet.
+En respons som allerede regnes som suksess av det konfigurerte `successStatus`-predikatet retry-es aldri, selv om statuskoden er i den retryable mengden (f.eks. hvis en konsument bevisst godtar `503` som suksess).
+
+For konstant backoff finnes `RetryConfig.fixed(maxRetries, delay)`. Konsumenter kan også sende inn en Arrow `Schedule<AttemptOutcome, *>` direkte. På den bare `RetryConfig(schedule = ...)`-konstruktøren defaulter `retryOn` til `NeverRetry`, så den retry-er ikke før du eksplisitt opt-iner (f.eks. `retryOn = RetryOnServerErrorsAndNetwork` eller `withRetryOn(...)`). Fabrikkene `exponential`/`fixed` defaulter derimot til `RetryOnServerErrorsAndNetwork`, siden det å velge en av dem allerede uttrykker eksplisitt retry-intensjon:
+
+```kotlin
+val retryConfig = RetryConfig(
+    schedule = Schedule.spaced<AttemptOutcome>(200.milliseconds)
+        .zipLeft(Schedule.recurs(3)),
+    retryOn = RetryOnServerErrorsAndNetwork,
+)
+```
+
+Per-request override fungerer som for `successStatus` og `loggingConfig`:
+
+```kotlin
+val response = klient.post<String>(URI.create("https://example.com/api/idempotent-key")) {
+    json(payload)
+    retryConfig = RetryConfig.fixed(maxRetries = 2, delay = 100.milliseconds)
+}
+```
+
+`HttpKlientMetadata` får alltid med `attempts`, `attemptDurations` og `totalDuration`, både på vellykkede svar og på alle `HttpKlientError`-varianter. Disse kan brukes til å få et bilde av hvor mye tid og hvor mange retries et kall faktisk forbrukte.
+
+`onExcessiveRetries` kalles når antall retries (`attempts - 1`) er minst `excessiveRetriesThreshold`. Default-callbacken logger en WARN — bruk `withoutExcessiveRetriesNotification()` for å skru av varslingen igjen, eller `notifyOnExcessiveRetries(threshold) { ... }` for å eksponere som metrikk.
+
+### Retryable-flagg
+
+Hver `HttpKlientError` (og `AttemptOutcome` internt) eksponerer `retryable: Boolean`. Retry-loopen bruker dette som en **hard gate** — den vil aldri forsøke på nytt for utfall som regnes som permanente, uansett hva [RetryConfig.retryOn] returnerer:
+
+| Variant | `retryable` |
+|---|---|
+| `Timeout`, `NetworkError` | `true` |
+| `UventetStatus` med status `408`, `425`, `429`, `500`, `502`, `503`, `504` | `true` |
+| `UventetStatus` med øvrige statuser | `false` |
+| `InvalidRequest`, `SerializationError`, `DeserializationError`, `AuthError`, `CircuitBreakerOpen` | `false` |
+
+Dvs. selv et altfor liberalt `retryOn = { true }`-predikat vil aldri retry-e en validerings- eller deserialiseringsfeil eller en `404`.
+
+## Circuit breaker
+
+`HttpKlient` har valgfri circuit breaker-støtte basert på Arrow Resilience `CircuitBreaker`.
+Default er `CircuitBreakerConfig.None`, dvs. ingen circuit breaker.
+
+Konfigurasjon gjøres fluent på samme måte som retry:
+
+```kotlin
+val klient = HttpKlient(clock = clock) {
+    defaultCircuitBreaker = CircuitBreakerConfig.count(
+        name = "min-nedstroem",
+        maxFailures = 5,
+        resetTimeout = 30.seconds,
+    ).withExponentialBackoff(
+        factor = 2.0,
+        maxResetTimeout = 5.minutes,
+    ).doOnOpen {
+        meterRegistry.counter("nedstrom_circuit_breaker_open").increment()
+    }
+}
+```
+
+`CircuitBreakerConfig.count(name, maxFailures, resetTimeout)` åpner etter `maxFailures` feil som matcher `failurePredicate`.
+`name` er den stabile nøkkelen for breaker-state innenfor én `HttpKlient`-instans.
+Bruk derfor samme navn for requests som skal dele breaker, også hvis configen bygges inline per request.
+`name` må være lav-kardinalitet og stabil (typisk navnet på en nedstrøms-tjeneste): breaker-instansen caches for klientens levetid per distinkt navn, så ikke utled navnet fra host, tenant eller request-id.
+Default-predikatet er `CircuitBreakerOnRetryableErrors`, dvs. de samme forbigående feilene som er retryable (`Timeout`, `NetworkError`, og statusene `408`/`425`/`429`/`500`/`502`/`503`/`504`).
+Permanente feil som `404`, valideringsfeil, serialiseringsfeil og deserialiseringsfeil teller ikke mot circuit breakeren.
+
+For tidsvindu finnes også sliding-window-strategi:
+
+```kotlin
+val config = CircuitBreakerConfig.slidingWindow(
+    name = "min-nedstroem-window",
+    maxFailures = 10,
+    windowDuration = 1.minutes,
+    resetTimeout = 30.seconds,
+)
+```
+
+Per-request override fungerer som for `retryConfig`:
+
+```kotlin
+val response = klient.get<String>(URI.create("https://example.com/api")) {
+    circuitBreakerConfig = CircuitBreakerConfig.count(
+        name = "example-api",
+        maxFailures = 2,
+        resetTimeout = 10.seconds,
+    )
+}
+```
+
+Circuit breaker-state er lokal for én `HttpKlient`-instans.
+Det finnes ingen statisk/global state.
+Hvis samme `name` brukes flere ganger på samme klient, deles state for den navngitte breakeren i klientinstansen.
+Dette unngår at nye, semantisk like lambdaer i inline config lager hver sin breaker.
+
+Ved åpen breaker returnerer klienten `HttpKlientError.CircuitBreakerOpen` med `metadata.attempts = 0`, siden ingen HTTP-forsøk ble utført.
+
+`CircuitBreakerConfig.Enabled` eksponerer åpningsstrategien via vår egen `CircuitBreakerOpeningStrategy` (`Count`/`SlidingWindow`) og `TimeSource` direkte.
+Strategitypen er tidskilde-fri, slik at `timeSource` på `CircuitBreakerConfig.Enabled` er den eneste tidskilden.
+Den mappes til Arrow sin `CircuitBreaker.OpeningStrategy` først i `toCircuitBreaker()`.
+
+### Samspill med retry
+
+Circuit breakeren ligger utenpå retry-eksekveringen.
+Det betyr at retry først får bruke sitt budsjett, og deretter vurderer circuit breakeren sluttresultatet.
+Et kall som lykkes etter retry teller derfor ikke som circuit breaker-feil, mens et kall som ender med retryable feil etter at retry-budsjettet er brukt opp teller én gang.
+
+## Auth-token
+
+`HttpKlient` støtter både klient-nivå og per-request bearer-token basert på `AccessToken` fra `common`. Klienten setter `Authorization: Bearer <token>` automatisk hvis ikke konsumenten allerede har satt `Authorization`-headeren eksplisitt.
+
+Klient-nivå (kalles foran hver request — egnet for `texas`/Token-X-flyter):
+
+```kotlin
+val klient: HttpKlient = HttpKlient(clock = clock) {
+    authTokenProvider = { tokenService.systemToken("api://app-x") } // AccessToken
+}
+```
+
+Per-request (overstyrer klient-default):
+
+```kotlin
+val response = klient.get<MinDto>(URI.create("https://example.com/api")) {
+    bearerToken(innkommendeAccessToken)
+}
+```
+
+Hvis `authTokenProvider` kaster, returneres `HttpKlientError.AuthError` (ikke-retryable) og _ingen_ HTTP-kall blir gjort. `metadata.attempts` er `0` for denne feiltypen.
+
+## Redirects
+
+Den underliggende `java.net.http.HttpClient` følger ikke redirects som standard ([HttpClient.Redirect.NEVER]), slik at `3xx`-svar dukker opp eksplisitt som `UventetStatus` i stedet for å bli fulgt stille.
+Sett `followRedirects` på klient-configen for å endre dette:
+
+```kotlin
+val klient = HttpKlient(clock = clock) {
+    followRedirects = HttpClient.Redirect.NORMAL
+}
+```
+
+## Observability / metrikker
+
+`httpklient` eksponerer ikke egne metrikker.
+I NAIS-tjenester gir auto-instrumentering allerede HTTP-klient-metrikker (latency, status, antall kall) uten kode i biblioteket:
+
+```yaml
+observability:
+  autoInstrumentation:
+    enabled: true
+    runtime: java
+```
+
+Trenger du domenespesifikke tellere (f.eks. per nedstrøms-tjeneste eller per retry-forbruk), kan du bruke de eksisterende hookene: `onExcessiveRetries` på `RetryConfig` og `doOnOpen` / `doOnClosed` / `doOnHalfOpen` / `doOnRejectedTask` på circuit breaker-configen, samt `metadata.attempts` / `metadata.totalDuration` på hvert svar.
+
+## Begrensninger og videre arbeid
+
+- **Binære bodyer / nedlasting**: requests og responser håndteres i dag kun som `String` (`BodyHandlers.ofString` / `BodyPublishers.ofString`).
+  Fil- og byte-baserte over-/nedlastinger er TODO og legges til ved behov.
+- **`Retry-After`**: klienten respekterer foreløpig ikke `Retry-After`-headeren på `429`/`503`; backoff styres kun av den konfigurerte `Schedule`.
+  Å lese `Retry-After` for retryable responser er TODO.
+

--- a/httpklient/build.gradle.kts
+++ b/httpklient/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("tiltakspenger-lib-conventions")
+    alias(libs.plugins.kover)
+}
+
+dependencies {
+    api(libs.arrow.core)
+    api(libs.arrow.resilience)
+    api(project(":common"))
+    // kotlin-logging er del av httpklient sitt public API: HttpKlientLoggingConfig.logger eksponerer KLogger.
+    api(libs.kotlin.logging.jvm)
+
+    // logging-modulen brukes kun internt (Sikkerlogg i InternalLogging), så den skal ikke eksponeres på konsumentenes compile classpath.
+    implementation(project(":logging"))
+    implementation(project(":json"))
+    implementation(libs.kotlinx.coroutines.core)
+    // kotlin-reflect brukes direkte internt (kotlin.reflect.jvm.javaType i InternalResponseConversion); deklareres eksplisitt i stedet for å lene seg på en transitiv kopi fra json/Jackson.
+    // kotlin("reflect") holder versjonen i synk med Kotlin-pluginet.
+    implementation(kotlin("reflect"))
+
+    testImplementation(project(":test-common"))
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                minBound(100)
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.koverVerify)
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpKlient.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlient.kt
@@ -1,0 +1,278 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import java.net.URI
+import java.net.http.HttpClient
+import java.time.Clock
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+interface HttpKlient {
+    /**
+     * Den eneste metoden en [HttpKlient]-implementasjon må implementere.
+     *
+     * Tar en ferdig materialisert [HttpKlientRequest] (bygget av de reified verb-extensionene) i stedet for en builder-callback, slik at implementasjoner får rene data og fakes kan asserte direkte på requesten.
+     * Tar [responseType] som [KType] (ikke `KClass`) slik at generiske parametre overlever gjennom Jackson-deserialiseringen — `request<List<Foo>>(...)` produserer faktisk `List<Foo>`, ikke `List<LinkedHashMap>`.
+     * De reified extensionene bruker [typeOf] for å fange typen.
+     */
+    suspend fun <Response : Any> request(
+        request: HttpKlientRequest,
+        responseType: KType,
+    ): Either<HttpKlientError, HttpKlientResponse<Response>>
+
+    companion object {
+        /**
+         * Eneste public måte å lage en [HttpKlient] på.
+         * Faktisk implementasjon ([JavaHttpKlient]) er intern slik at konsumenter ikke binder seg til den konkrete typen.
+         *
+         * [clock] er påkrevd for å sikre at all tidsmåling går via samme klokke (se AGENTS.md).
+         */
+        operator fun invoke(
+            clock: Clock,
+            config: HttpKlientConfig.() -> Unit = {},
+        ): HttpKlient = JavaHttpKlient(HttpKlientConfig(clock).apply(config))
+    }
+
+    /**
+     * Konfigurasjon av en [HttpKlient].
+     * Alle felter minus clock har defaultverdier som gjør at klienten fungerer ut av boksen uten resilience, auth eller logging.
+     * Per-request overstyringer via [RequestBuilder] tar alltid presedens over disse defaultene.
+     */
+    class HttpKlientConfig(
+        /**
+         * Klokken som brukes til all tidsmåling i klienten (retry-timing, metadata, auth-token-utløp).
+         * Påkrevd; ingen default i produksjonskode (se AGENTS.md).
+         */
+        val clock: Clock,
+    ) {
+        /**
+         * Connect-timeout for den underliggende `java.net.http.HttpClient`.
+         * Brukes kun ved opprettelse av selve [java.net.http.HttpClient]-instansen.
+         */
+        var connectTimeout: Duration = 10.seconds
+
+        /**
+         * Default per-request timeout.
+         * Kan overstyres per request via [RequestBuilder.timeout].
+         */
+        var defaultTimeout: Duration = 30.seconds
+
+        /**
+         * Redirect-policy for den underliggende `java.net.http.HttpClient`.
+         * Default er [HttpClient.Redirect.NEVER] slik at konsumenten ser `3xx`-svar eksplisitt i stedet for at klienten følger dem stille.
+         * Sett til [HttpClient.Redirect.NORMAL] for å følge redirects (utenom HTTPS→HTTP-nedgradering).
+         */
+        var followRedirects: HttpClient.Redirect = HttpClient.Redirect.NEVER
+
+        /**
+         * Default predikat for hvilke HTTP-statuser som regnes som suksess.
+         * Kan overstyres per request via [RequestBuilder.successStatus].
+         */
+        var successStatus: (Int) -> Boolean = HttpStatusSuccess.is2xx
+
+        /**
+         * Default logging-config.
+         * [HttpKlientLoggingConfig.Disabled] betyr ingen logging.
+         * Kan overstyres per request via [RequestBuilder.logging] / [RequestBuilder.disableLogging].
+         */
+        var logging: HttpKlientLoggingConfig = HttpKlientLoggingConfig.Disabled
+
+        /**
+         * Default retry-config.
+         * [RetryConfig.None] betyr ingen retries.
+         * Kan overstyres per request via [RequestBuilder.retryConfig].
+         */
+        var defaultRetry: RetryConfig = RetryConfig.None
+
+        /**
+         * Default circuit breaker-config.
+         * [CircuitBreakerConfig.None] betyr ingen circuit breaker.
+         * Kan overstyres per request via [RequestBuilder.circuitBreakerConfig].
+         * State er lokal til den enkelte [HttpKlient]-instansen.
+         */
+        var defaultCircuitBreaker: CircuitBreakerConfig = CircuitBreakerConfig.None
+
+        /**
+         * Valgfri token-provider.
+         * Når satt vil klienten kalle denne foran hver request og legge resultatet i `Authorization: Bearer <token>`-headeren (med mindre konsumenten allerede har satt `Authorization` eksplisitt, eller har satt en per-request token via [RequestBuilder.bearerToken]).
+         * Hvis providern kaster, returneres [HttpKlientError.AuthError] og det HTTP-kallet gjøres aldri.
+         */
+        var authTokenProvider: (suspend () -> AccessToken)? = null
+    }
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.request(
+    uri: URI,
+    method: HttpMethod,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, method),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.get(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.GET),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.post(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.POST),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.put(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.PUT),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.patch(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.PATCH),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.delete(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.DELETE),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.head(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.HEAD),
+        responseType,
+    )
+}
+
+suspend inline fun <reified Response : Any> HttpKlient.options(
+    uri: URI,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    val responseType = typeOf<Response>()
+    return request(
+        RequestBuilder(uri).apply { build.invoke(this) }.materialize(responseType, HttpMethod.OPTIONS),
+        responseType,
+    )
+}
+
+/**
+ * Shorthand for det vanligste POST-tilfellet: serialiser [body]-DTO-en til JSON via `tiltakspenger-libs/json`.
+ * Tilsvarer `post<R>(uri) { json(body); build() }`.
+ *
+ * For en allerede serialisert JSON-`String` finnes en egen [String]-overload som sender strengen verbatim (uten å serialisere den på nytt).
+ * Hvis du trenger å sende rå tekst (ikke-JSON) eller en spesifikk `Content-Type`, bruk lambda-formen [post] med [RequestBuilder.body] / [RequestBuilder.header].
+ */
+suspend inline fun <reified Response : Any> HttpKlient.post(
+    uri: URI,
+    body: Any,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = post(uri) {
+    json(body)
+    build.invoke(this)
+}
+
+/**
+ * Shorthand for POST av en allerede serialisert JSON-`String`.
+ * Strengen sendes verbatim som body (den serialiseres _ikke_ på nytt), og `Content-Type: application/json` settes hvis den mangler.
+ * Denne overloaden finnes nettopp for å unngå at en JSON-streng dobbelt-serialiseres slik [post] med `body: Any` ville gjort.
+ */
+suspend inline fun <reified Response : Any> HttpKlient.post(
+    uri: URI,
+    body: String,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = post(uri) {
+    json(body)
+    build.invoke(this)
+}
+
+/**
+ * Shorthand for det vanligste PUT-tilfellet: serialiser [body]-DTO-en til JSON via `tiltakspenger-libs/json`.
+ * Se [post] for [String]-overloaden og når lambda-formen skal foretrekkes.
+ */
+suspend inline fun <reified Response : Any> HttpKlient.put(
+    uri: URI,
+    body: Any,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = put(uri) {
+    json(body)
+    build.invoke(this)
+}
+
+/**
+ * Shorthand for PUT av en allerede serialisert JSON-`String`, sendt verbatim.
+ * Se [post] med `body: String` for detaljer.
+ */
+suspend inline fun <reified Response : Any> HttpKlient.put(
+    uri: URI,
+    body: String,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = put(uri) {
+    json(body)
+    build.invoke(this)
+}
+
+/**
+ * Shorthand for det vanligste PATCH-tilfellet: serialiser [body]-DTO-en til JSON via `tiltakspenger-libs/json`.
+ * Se [post] for [String]-overloaden og når lambda-formen skal foretrekkes.
+ */
+suspend inline fun <reified Response : Any> HttpKlient.patch(
+    uri: URI,
+    body: Any,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = patch(uri) {
+    json(body)
+    build.invoke(this)
+}
+
+/**
+ * Shorthand for PATCH av en allerede serialisert JSON-`String`, sendt verbatim.
+ * Se [post] med `body: String` for detaljer.
+ */
+suspend inline fun <reified Response : Any> HttpKlient.patch(
+    uri: URI,
+    body: String,
+    crossinline build: RequestBuilder.() -> Unit = {},
+): Either<HttpKlientError, HttpKlientResponse<Response>> = patch(uri) {
+    json(body)
+    build.invoke(this)
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpKlientError.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlientError.kt
@@ -1,0 +1,192 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.resilience.CircuitBreaker
+import kotlin.time.Duration
+
+/**
+ * Venstresiden i alt `httpklient` returnerer (`Either<HttpKlientError, ...>`).
+ * Hver variant svarer til ett konkret feilpunkt i livssyklusen til et kall, og bevarer så mye [metadata] (rå request/respons, headere, timing, antall forsøk) som finnes på det punktet.
+ *
+ * ## Gruppering
+ * Variantene er delt i tre under-grensesnitt langs spørsmålet **«så serveren requesten min?»** — som er det som faktisk styrer hvor trygt det er å retry-e og om kallet kan ha hatt sideeffekter:
+ *
+ * - [RequestIkkeSendt] — vi kom aldri så langt som til å sende noe over nettverket.
+ *   Serveren har _garantert_ ikke sett requesten, så det er trygt å bygge en ny og forsøke på nytt.
+ * - [IngenRespons] — et HTTP-forsøk ble startet, men vi fikk aldri en fullstendig respons.
+ *   Det er _ukjent_ om serveren rakk å motta og behandle requesten (relevant for ikke-idempotente kall).
+ * - [ResponsMottatt] — serveren svarte.
+ *   Vi har en [ResponsMottatt.statusCode], men noe gikk likevel galt (feilstatus eller en body vi ikke klarte å deserialisere).
+ *
+ * Du kan matche enten på den konkrete varianten eller på gruppen, avhengig av hvor finmasket du trenger å være:
+ * ```
+ * when (error) {
+ *     is HttpKlientError.RequestIkkeSendt -> // trygt å retry-e / logg konfig-feil
+ *     is HttpKlientError.IngenRespons -> // ukjent utfall — vær varsom med ikke-idempotente kall
+ *     is HttpKlientError.ResponsMottatt -> // inspiser error.statusCode
+ * }
+ * ```
+ */
+sealed interface HttpKlientError {
+    val metadata: HttpKlientMetadata
+
+    /**
+     * `true` hvis et nytt forsøk på _samme_ request _kan_ gi et annet utfall.
+     * `false` betyr at vi vet at retries er bortkastet (validerings-, serialiserings-, deserialiseringsfeil, og statuser som ikke er i [isRetryableStatusCode] — det gjelder de fleste 4xx, men merk at `408`, `425` og `429` _er_ retryable).
+     * Retry-loopen bruker dette som hard gate — den vil aldri forsøke på nytt for `retryable = false`, uansett hva [no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig.retryOn] returnerer.
+     */
+    val retryable: Boolean
+
+    /**
+     * Feil som oppsto _før_ noe ble sendt over nettverket — bygging, serialisering, auth eller en åpen circuit breaker stoppet kallet.
+     * Serveren har garantert ikke sett requesten, så det er ingen risiko for sideeffekter på serversiden uansett hva konsumenten gjør videre.
+     * Merk at «ingen sideeffekter» ikke betyr «alltid nyttig å forsøke på nytt umiddelbart»: [AuthError] og [CircuitBreakerOpen] har `retryable = false`, fordi et nytt forsøk på samme request typisk vil feile på samme måte til underliggende tilstand endrer seg.
+     * [HttpKlientMetadata.attempts] er `0` for alle disse, og det finnes aldri en respons.
+     */
+    sealed interface RequestIkkeSendt : HttpKlientError {
+        val throwable: Throwable
+    }
+
+    /**
+     * Et HTTP-forsøk ble startet, men avsluttet uten en fullstendig respons (timeout eller nettverks-/IO-feil).
+     * Det er _ukjent_ om serveren rakk å motta og behandle requesten — vær derfor varsom med blind retry av ikke-idempotente kall (`POST`/`PATCH`).
+     * [throwable] er den underliggende JDK-exceptionen, allerede pakket ut av `CompletionException`/`ExecutionException`.
+     */
+    sealed interface IngenRespons : HttpKlientError {
+        val throwable: Throwable
+    }
+
+    /**
+     * Serveren returnerte en fullstendig HTTP-respons, men kallet regnes likevel som mislykket: enten fordi statusen ikke ble godtatt som suksess ([UventetStatus]) eller fordi en suksess-body ikke lot seg deserialisere ([DeserializationError]).
+     * Siden serveren faktisk svarte, er både [statusCode] og rå-responsen [body] alltid tilgjengelig for denne gruppen (i tillegg til [responseHeaders] fra [metadata]).
+     */
+    sealed interface ResponsMottatt : HttpKlientError {
+        val statusCode: Int
+        val body: String
+    }
+
+    /**
+     * Forsøket time-et ut.
+     * Trigges av `java.net.http.HttpTimeoutException` fra JDK-klienten — enten request-timeout ([RequestBuilder.timeout] / `HttpKlientConfig.defaultTimeout`) eller connect-timeout (`HttpKlientConfig.connectTimeout`).
+     * Forbigående, derfor `retryable = true`.
+     */
+    data class Timeout(
+        override val throwable: Throwable,
+        override val metadata: HttpKlientMetadata,
+    ) : IngenRespons {
+        override val retryable = true
+    }
+
+    /**
+     * Alle andre feil fra `HttpClient.sendAsync(...)` som _ikke_ er en timeout: connection refused, connection reset, DNS-oppslag som feiler, tom/malformert respons, brutt stream osv. (typisk `IOException`/`ConnectException`).
+     * Forbigående, derfor `retryable = true`.
+     */
+    data class NetworkError(
+        override val throwable: Throwable,
+        override val metadata: HttpKlientMetadata,
+    ) : IngenRespons {
+        override val retryable = true
+    }
+
+    /**
+     * Requesten lot seg ikke bygge til en gyldig `java.net.http.HttpRequest`.
+     * Trigges av `IllegalArgumentException` fra JDK sin `HttpRequest.Builder` (f.eks. et ulovlig headernavn eller en uri med et scheme som ikke er `http`/`https` — scheme-validering er delegert til JDK-klienten, ikke noe vi sjekker selv).
+     * Permanent feil i konsumentens egen kode, derfor `retryable = false`.
+     */
+    data class InvalidRequest(
+        override val throwable: Throwable,
+        override val metadata: HttpKlientMetadata,
+    ) : RequestIkkeSendt {
+        override val retryable = false
+    }
+
+    /**
+     * Serialisering av request-body med [no.nav.tiltakspenger.libs.json.serialize] (Jackson) kastet — f.eks. en selvrefererende DTO.
+     * Gjelder kun `json(...)`-bodyer; rå bodyer serialiseres ikke.
+     * Permanent feil i konsumentens DTO, derfor `retryable = false`.
+     */
+    data class SerializationError(
+        override val throwable: Throwable,
+        override val metadata: HttpKlientMetadata,
+    ) : RequestIkkeSendt {
+        override val retryable = false
+    }
+
+    /**
+     * Serveren svarte, men [statusCode] ble _ikke_ godtatt som suksess av det konfigurerte `successStatus`-predikatet (default [HttpStatusSuccess.is2xx]).
+     *
+     * Merk navnet: dette er **ikke** bokstavelig «status utenfor 2xx».
+     * Suksess-predikatet er konfigurerbart per klient og per request ([RequestBuilder.successStatus]), så en `2xx` kan havne her (hvis du f.eks. kun godtar `200`), og en non-2xx kan regnes som suksess.
+     * Trenger du å skille mellom flere suksess-statuser (f.eks. `200` vs `209`), les `statusCode` på [HttpKlientResponse] i suksess-grenen i stedet.
+     *
+     * Retryability følger [isRetryableStatusCode]: et utvalg statuser (408, 425, 429, 500, 502, 503, 504) er retryable, resten ikke.
+     */
+    data class UventetStatus(
+        override val statusCode: Int,
+        override val body: String,
+        override val metadata: HttpKlientMetadata,
+    ) : ResponsMottatt {
+        override val retryable = isRetryableStatusCode(statusCode)
+    }
+
+    /**
+     * Serveren svarte med en status som ble godtatt som suksess, men deserialisering av body til forventet type med Jackson (`objectMapper.readValue`) kastet.
+     * [throwable] er parse-feilen og [body] er den rå responsen, slik at konsumenten kan inspisere/feilsøke.
+     * Permanent gitt samme respons, derfor `retryable = false`.
+     */
+    data class DeserializationError(
+        val throwable: Throwable,
+        override val body: String,
+        override val statusCode: Int,
+        override val metadata: HttpKlientMetadata,
+    ) : ResponsMottatt {
+        override val retryable = false
+    }
+
+    /**
+     * Henting av auth-token (`HttpKlient.HttpKlientConfig.authTokenProvider`) kastet.
+     * Ingen HTTP-forsøk er utført ([HttpKlientMetadata.attempts] er `0`).
+     * Ikke-retryable som default — token-feil er typisk enten konfig-feil (permanente) eller transient nedstrøms-trøbbel som konsumenten heller bør håndtere på et høyere nivå.
+     */
+    data class AuthError(
+        override val throwable: Throwable,
+        override val metadata: HttpKlientMetadata,
+    ) : RequestIkkeSendt {
+        override val retryable = false
+    }
+
+    /**
+     * Requesten ble avvist fordi circuit breakeren for denne [HttpKlient]-instansen er åpen.
+     * Trigges av Arrow Resilience sin [CircuitBreaker.ExecutionRejected].
+     * Ingen HTTP-forsøk er utført ([HttpKlientMetadata.attempts] er `0`), og feilen er derfor ikke retryable i klientens interne retry-loop.
+     */
+    data class CircuitBreakerOpen(
+        override val throwable: CircuitBreaker.ExecutionRejected,
+        override val metadata: HttpKlientMetadata,
+    ) : RequestIkkeSendt {
+        override val retryable = false
+    }
+}
+
+/**
+ * Et utvalg statuser regnes som mulig forbigående og dermed retryable:
+ * 408 Request Timeout, 425 Too Early, 429 Too Many Requests, 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable og 504 Gateway Timeout.
+ * Alle andre statuser regnes som permanente i retry-sammenheng.
+ */
+internal fun isRetryableStatusCode(statusCode: Int): Boolean =
+    statusCode in retryableStatusCodes
+
+private val retryableStatusCodes = setOf(408, 425, 429, 500, 502, 503, 504)
+
+/**
+ * Convenience-aksessorer som peker rett inn i [HttpKlientError.metadata].
+ * Lar konsumenter slippe å skrive `error.metadata.requestHeaders` osv., samtidig som vi beholder [HttpKlientMetadata] som eneste datatype og sannhetskilde for disse feltene.
+ * `statusCode` eksponeres bevisst _ikke_ her — kun [HttpKlientError.ResponsMottatt] har en garantert non-null `statusCode`, mens de andre gruppene ikke har noen status.
+ * Bruk `metadata.statusCode` hvis du trenger den generiske, nullable verdien.
+ */
+val HttpKlientError.rawRequestString: String get() = metadata.rawRequestString
+val HttpKlientError.rawResponseString: String? get() = metadata.rawResponseString
+val HttpKlientError.requestHeaders: Map<String, List<String>> get() = metadata.requestHeaders
+val HttpKlientError.responseHeaders: Map<String, List<String>> get() = metadata.responseHeaders
+val HttpKlientError.attempts: Int get() = metadata.attempts
+val HttpKlientError.attemptDurations: List<Duration> get() = metadata.attemptDurations
+val HttpKlientError.totalDuration: Duration get() = metadata.totalDuration

--- a/httpklient/src/main/kotlin/httpklient/HttpKlientLoggingConfig.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlientLoggingConfig.kt
@@ -1,0 +1,31 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import io.github.oshai.kotlinlogging.KLogger
+
+data class HttpKlientLoggingConfig(
+    val logger: KLogger? = null,
+    val loggTilSikkerlogg: Boolean = false,
+    val inkluderHeadere: Boolean = false,
+) {
+    companion object {
+        val Disabled = HttpKlientLoggingConfig()
+
+        fun build(build: HttpKlientLoggingConfigBuilder.() -> Unit): HttpKlientLoggingConfig {
+            return HttpKlientLoggingConfigBuilder().apply(build).build()
+        }
+    }
+}
+
+class HttpKlientLoggingConfigBuilder {
+    var logger: KLogger? = null
+    var loggTilSikkerlogg: Boolean = false
+    var inkluderHeadere: Boolean = false
+
+    fun build(): HttpKlientLoggingConfig {
+        return HttpKlientLoggingConfig(
+            logger = logger,
+            loggTilSikkerlogg = loggTilSikkerlogg,
+            inkluderHeadere = inkluderHeadere,
+        )
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpKlientMetadata.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlientMetadata.kt
@@ -1,0 +1,64 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import kotlin.time.Duration
+
+/**
+ * Beskrivelse av en faktisk utført request/response (eller forsøk på dette).
+ * Skal fylles ut eksplisitt av produsenten — det finnes ingen "fornuftige" default-verdier for denne typen informasjon, og defaults vil bare maskere bugs hvor felter ikke blir satt riktig.
+ *
+ * @property requestHeaders Kun headerne klienten selv setter på requesten:
+ *   - konsumentens egne headere (via `RequestBuilder.header`/`addHeader`),
+ *   - klientens default-headere: `Accept: application/json` for response-typer som ikke er `String`/`Unit`, og `Content-Type: application/json` for JSON-body (eller `application/x-www-form-urlencoded` for `formUrlEncoded`),
+ *   - en eventuell bearer-token materialisert av klienten, i klartekst som `Authorization: Bearer ...` (bruk derfor [rawRequestString], som redakterer sensitive headere, ved logging).
+ *   Bevarer innsettings-rekkefølge fra `RequestBuilder`; klientens default-headere havner til slutt.
+ *   Inneholder bevisst _ikke_ transport-headerne `java.net.http.HttpClient` legger på selv ved sending — på Java 21 er det `Host`, `User-Agent` (`Java-http-client/21`) og `Content-Length` (sistnevnte for body-requester).
+ *   Disse settes i JDK-ens ikke-offentlige connection-lag og eksponeres ikke via `HttpRequest.headers()` (verifisert), så vi kan verken lese dem tilbake fra klienten eller speile dem her uten å reimplementere JDK-intern oppførsel — som ville bundet oss til Java-versjonen.
+ * @property responseHeaders Headere fra HTTP-responsen.
+ *   Rekkefølgen kommer fra JDK `HttpHeaders.map()` og er typisk alfabetisk (case-insensitiv) — ikke wire-rekkefølgen.
+ */
+data class HttpKlientMetadata(
+    val rawRequestString: String,
+    val rawResponseString: String?,
+    val requestHeaders: Map<String, List<String>>,
+    val responseHeaders: Map<String, List<String>>,
+    val statusCode: Int?,
+    /**
+     * Antall forsøk som ble utført, inkludert det første.
+     * `1` betyr at det ikke ble retry-et, og `0` at det aldri ble gjort et HTTP-forsøk (pre-flight-feil som bygging/serialisering/auth eller en åpen circuit breaker — jf. [HttpKlientError.RequestIkkeSendt]).
+     */
+    val attempts: Int,
+    /** Varighet per forsøk, i samme rekkefølge som de ble utført. */
+    val attemptDurations: List<Duration>,
+    /** Total veggklokketid for hele kallet, inkludert backoff mellom forsøk. */
+    val totalDuration: Duration,
+) {
+    init {
+        require(attempts >= 0) { "attempts kan ikke være negativ, var $attempts" }
+    }
+}
+
+/**
+ * Henter alle verdier for response-headeren [name], case-insensitivt (HTTP-headere er case-insensitive).
+ * Returnerer tom liste hvis headeren mangler.
+ */
+fun HttpKlientMetadata.responseHeaderValues(name: String): List<String> =
+    responseHeaders.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value.orEmpty()
+
+/**
+ * Henter første verdi for response-headeren [name], case-insensitivt, eller `null` hvis headeren mangler.
+ */
+fun HttpKlientMetadata.responseHeader(name: String): String? =
+    responseHeaderValues(name).firstOrNull()
+
+/**
+ * Henter alle verdier for request-headeren [name], case-insensitivt.
+ * Returnerer tom liste hvis headeren mangler.
+ */
+fun HttpKlientMetadata.requestHeaderValues(name: String): List<String> =
+    requestHeaders.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value.orEmpty()
+
+/**
+ * Henter første verdi for request-headeren [name], case-insensitivt, eller `null` hvis headeren mangler.
+ */
+fun HttpKlientMetadata.requestHeader(name: String): String? =
+    requestHeaderValues(name).firstOrNull()

--- a/httpklient/src/main/kotlin/httpklient/HttpKlientRequest.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlientRequest.kt
@@ -1,0 +1,53 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import java.net.URI
+import kotlin.time.Duration
+
+/**
+ * En ferdig materialisert request, slik den ser ut etter at [RequestBuilder] er kjørt og klientens default-headere er lagt til.
+ *
+ * Dette er typen [HttpKlient.request] mottar.
+ * De reified verb-extensionene bygger en [RequestBuilder], materialiserer den til denne typen, og kaller [HttpKlient.request] med den.
+ * Implementasjoner (den virkelige klienten og `HttpKlientFake`) får dermed rene data å jobbe med i stedet for en builder-callback, og fakes kan asserte direkte på requesten uten å røre [RequestBuilder].
+ *
+ * Headere bevarer innsettingsrekkefølge, med eventuelle default-headere som klienten legger til (JSON `Content-Type` for body, `Accept` for response-type), til slutt.
+ * En eksplisitt `Authorization`-header satt via [RequestBuilder.header] er inkludert her, og beholdes uendret av implementasjonen.
+ * Det som _ikke_ ligger her, er en bearer-token fra [authToken] eller klientens `authTokenProvider`; den resolves og materialiseres til `Authorization: Bearer ...` av implementasjonen ved sending.
+ *
+ * Per-request-overstyringer ([retryConfig], [circuitBreakerConfig], [loggingConfig], [successStatus]) følger med fordi implementasjonen trenger dem.
+ * De er funksjons-/konfig-verdier; `equals`/`hashCode` faller derfor tilbake på referanselikhet for disse feltene, så tester bør asserte på [uri], [method], [headers] og [body].
+ */
+data class HttpKlientRequest(
+    val uri: URI,
+    val method: HttpMethod,
+    val headers: Map<String, List<String>>,
+    val body: Body?,
+    val timeout: Duration?,
+    val authToken: AccessToken?,
+    val successStatus: ((Int) -> Boolean)?,
+    val loggingConfig: HttpKlientLoggingConfig?,
+    val retryConfig: RetryConfig?,
+    val circuitBreakerConfig: CircuitBreakerConfig?,
+) {
+    sealed interface Body {
+        /**
+         * Rå tekst-body.
+         * `httpklient` legger ikke til JSON-headere for denne varianten.
+         */
+        data class Raw(val body: String) : Body
+
+        /**
+         * Ferdigserialisert JSON-string.
+         * `httpklient` legger til standard JSON-headere hvis de mangler.
+         */
+        data class RawJson(val body: String) : Body
+
+        /**
+         * DTO/verdi som serialiseres med `tiltakspenger-libs/json` før requesten sendes.
+         */
+        data class Json(val value: Any) : Body
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpKlientResponse.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpKlientResponse.kt
@@ -1,0 +1,25 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import kotlin.time.Duration
+
+data class HttpKlientResponse<out Body>(
+    val statusCode: Int,
+    val body: Body,
+    val metadata: HttpKlientMetadata,
+) {
+    init {
+        require(statusCode in 100..999) { "statusCode må være en tresifret HTTP-statuskode" }
+    }
+
+    /**
+     * Convenience-aksessorer som peker rett inn i [metadata].
+     * Lar konsumenter slippe å skrive `response.metadata.requestHeaders` osv., samtidig som vi beholder [HttpKlientMetadata] som eneste datatype og sannhetskilde for disse feltene.
+     */
+    val rawRequestString: String get() = metadata.rawRequestString
+    val rawResponseString: String? get() = metadata.rawResponseString
+    val requestHeaders: Map<String, List<String>> get() = metadata.requestHeaders
+    val responseHeaders: Map<String, List<String>> get() = metadata.responseHeaders
+    val attempts: Int get() = metadata.attempts
+    val attemptDurations: List<Duration> get() = metadata.attemptDurations
+    val totalDuration: Duration get() = metadata.totalDuration
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpMethod.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpMethod.kt
@@ -1,0 +1,11 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+enum class HttpMethod {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    HEAD,
+    OPTIONS,
+}

--- a/httpklient/src/main/kotlin/httpklient/HttpStatusSuccess.kt
+++ b/httpklient/src/main/kotlin/httpklient/HttpStatusSuccess.kt
@@ -1,0 +1,23 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+/**
+ * Ferdige predikater for hvilke HTTP-statuser som skal regnes som suksess.
+ * Brukes som `successStatus` på [HttpKlient.HttpKlientConfig] og per request via [RequestBuilder.successStatus].
+ */
+object HttpStatusSuccess {
+    /** Standard: alle `2xx`-statuser (200–299) regnes som suksess. */
+    val is2xx: (Int) -> Boolean = { statusCode -> statusCode in 200..299 }
+
+    /**
+     * Kun de eksplisitt oppgitte statuskodene regnes som suksess (f.eks. `exactly(200, 201, 204)`).
+     * Krever minst én kode.
+     */
+    fun exactly(vararg codes: Int): (Int) -> Boolean {
+        require(codes.isNotEmpty()) { "Må oppgi minst én statuskode" }
+        val allowed = codes.toHashSet()
+        return { statusCode -> statusCode in allowed }
+    }
+
+    /** Alle statuskoder i [range] (inklusiv) regnes som suksess (f.eks. `inRange(200..204)`). */
+    fun inRange(range: IntRange): (Int) -> Boolean = { statusCode -> statusCode in range }
+}

--- a/httpklient/src/main/kotlin/httpklient/InternalHeaders.kt
+++ b/httpklient/src/main/kotlin/httpklient/InternalHeaders.kt
@@ -1,0 +1,56 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import no.nav.tiltakspenger.libs.common.AccessToken
+
+internal fun Map<String, List<String>>.withDefaultJsonContentTypeHeader(): Map<String, List<String>> {
+    return withDefaultHeaders("Content-Type" to "application/json")
+}
+
+internal fun Map<String, List<String>>.withDefaultJsonAcceptHeader(): Map<String, List<String>> {
+    return withDefaultHeaders("Accept" to "application/json")
+}
+
+/**
+ * Setter `Authorization: Bearer <token>` hvis headeren ikke allerede er satt (case-insensitivt).
+ * Hvis konsumenten har satt `Authorization` eksplisitt, beholdes deres verdi uendret.
+ */
+internal fun Map<String, List<String>>.withBearerToken(accessToken: AccessToken): Map<String, List<String>> {
+    return withDefaultHeaders("Authorization" to "Bearer ${accessToken.token}")
+}
+
+/**
+ * Setter [defaults] hvis de mangler (case-insensitivt).
+ * Allokerer maks ett nytt Map per kall, og _bare_ hvis minst én default mangler; ellers returneres opprinnelig Map uendret.
+ * Bevarer iterasjonsrekkefølgen til opprinnelig Map, med nye headere lagt til til slutt.
+ */
+private fun Map<String, List<String>>.withDefaultHeaders(
+    vararg defaults: Pair<String, String>,
+): Map<String, List<String>> {
+    val missing = defaults.filterNot { (name, _) -> containsHeaderIgnoreCase(name) }
+    if (missing.isEmpty()) return this
+    return buildMap(size + missing.size) {
+        putAll(this@withDefaultHeaders)
+        missing.forEach { (name, value) -> put(name, listOf(value)) }
+    }
+}
+
+private fun Map<String, List<String>>.containsHeaderIgnoreCase(name: String): Boolean =
+    keys.any { it.equals(name, ignoreCase = true) }
+
+/**
+ * Headernavn (case-insensitivt) hvis verdier maskeres når headere gjengis i `rawRequestString` eller logges.
+ * Dette gjelder kun tekstrepresentasjonen/loggingen; den faktiske HTTP-requesten sendes med ekte verdier.
+ */
+private val sensitiveHeaderNames = setOf("authorization", "proxy-authorization", "cookie", "set-cookie")
+
+/**
+ * Returnerer headerne med verdiene til sensitive headere (f.eks. `Authorization`) erstattet med `***`.
+ * Brukes før headere puttes inn i [HttpKlientMetadata.rawRequestString] eller logges, slik at bearer-tokens og lignende ikke lekker til logger.
+ * Eksponert (ikke `internal`) slik at `HttpKlientFake` i `test-common` kan gjenbruke nøyaktig samme redaksjonslogikk og ikke divergere fra produksjonsklienten.
+ */
+fun Map<String, List<String>>.redactSensitiveHeaders(): Map<String, List<String>> {
+    if (keys.none { it.lowercase() in sensitiveHeaderNames }) return this
+    return mapValues { (name, values) ->
+        if (name.lowercase() in sensitiveHeaderNames) values.map { "***" } else values
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/InternalLogging.kt
+++ b/httpklient/src/main/kotlin/httpklient/InternalLogging.kt
@@ -1,0 +1,60 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import no.nav.tiltakspenger.libs.logging.Sikkerlogg
+
+internal fun HttpKlientLoggingConfig.logSuccess(
+    request: HttpKlientRequest,
+    statusCode: Int,
+    requestHeaders: Map<String, List<String>>,
+    responseHeaders: Map<String, List<String>>,
+) {
+    val message = melding(request, statusCode, requestHeaders, responseHeaders)
+    logger?.info { message }
+    if (loggTilSikkerlogg) {
+        Sikkerlogg.info { message }
+    }
+}
+
+internal fun HttpKlientLoggingConfig.logUventetStatus(
+    request: HttpKlientRequest,
+    error: HttpKlientError.UventetStatus,
+) {
+    val message = melding(request, error.statusCode, error.metadata.requestHeaders, error.metadata.responseHeaders)
+    if (error.statusCode in 400..499) {
+        logger?.warn { message }
+        if (loggTilSikkerlogg) {
+            Sikkerlogg.warn { "$message body=${error.body}" }
+        }
+    } else {
+        logger?.error { message }
+        if (loggTilSikkerlogg) {
+            Sikkerlogg.error { "$message body=${error.body}" }
+        }
+    }
+}
+
+internal fun HttpKlientLoggingConfig.logError(
+    request: HttpKlientRequest,
+    error: HttpKlientError,
+) {
+    val message = melding(request, null, error.metadata.requestHeaders, error.metadata.responseHeaders)
+    logger?.error { message }
+    if (loggTilSikkerlogg) {
+        Sikkerlogg.error { message }
+    }
+}
+
+private fun HttpKlientLoggingConfig.melding(
+    request: HttpKlientRequest,
+    statusCode: Int?,
+    requestHeaders: Map<String, List<String>>,
+    responseHeaders: Map<String, List<String>>,
+): String {
+    val status = statusCode?.let { " status=$it" }.orEmpty()
+    val headers = if (inkluderHeadere) {
+        " requestHeaders=${requestHeaders.redactSensitiveHeaders()} responseHeaders=${responseHeaders.redactSensitiveHeaders()}"
+    } else {
+        ""
+    }
+    return "HTTP ${request.method} ${request.uri}$status$headers"
+}

--- a/httpklient/src/main/kotlin/httpklient/InternalRequestConversion.kt
+++ b/httpklient/src/main/kotlin/httpklient/InternalRequestConversion.kt
@@ -1,0 +1,113 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.left
+import no.nav.tiltakspenger.libs.json.serialize
+import java.net.http.HttpRequest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.toJavaDuration
+
+internal fun HttpKlientRequest.toJavaHttpRequest(
+    defaultTimeout: Duration,
+    requestHeaders: Map<String, List<String>>,
+): Either<HttpKlientError, PreparedHttpKlientRequest> {
+    val bodyAsString = when (body) {
+        is HttpKlientRequest.Body.Json -> Either.catch { serialize(body.value) }
+            .getOrElse { e ->
+                return HttpKlientError.SerializationError(
+                    throwable = e,
+                    metadata = preFlightMetadata(
+                        rawRequestString = rawRequestString(
+                            requestHeaders = requestHeaders,
+                            bodyAsString = "<json-serialisering feilet>",
+                        ),
+                        requestHeaders = requestHeaders,
+                    ),
+                ).left()
+            }
+
+        is HttpKlientRequest.Body.Raw -> body.body
+
+        is HttpKlientRequest.Body.RawJson -> body.body
+
+        null -> null
+    }
+    val rawRequestString = rawRequestString(
+        requestHeaders = requestHeaders,
+        bodyAsString = bodyAsString,
+    )
+
+    return Either.catch {
+        // Vi validerer ikke scheme selv: JDK-klienten (HttpRequest.Builder.uri) avviser scheme som ikke er http/https og lowercaser scheme først (case-insensitivt, jf. RFC 3986 §3.1).
+        // Det gjenbruket gjør at vi hverken dupliserer eller divergerer fra spec-en; en ugyldig URI kaster IllegalArgumentException som fanges av Either.catch og mappes til InvalidRequest under.
+        val builder = HttpRequest.newBuilder()
+            .uri(uri)
+            .timeout((timeout ?: defaultTimeout).toJavaDuration())
+
+        requestHeaders.forEach { (name, values) -> values.forEach { value -> builder.header(name, value) } }
+
+        builder
+            .method(
+                method.name,
+                bodyAsString?.let { HttpRequest.BodyPublishers.ofString(it) } ?: HttpRequest.BodyPublishers.noBody(),
+            )
+            .build()
+            .let {
+                PreparedHttpKlientRequest(
+                    request = it,
+                    rawRequestString = rawRequestString,
+                )
+            }
+    }.mapLeft { e ->
+        HttpKlientError.InvalidRequest(
+            throwable = e,
+            metadata = preFlightMetadata(
+                rawRequestString = rawRequestString,
+                requestHeaders = requestHeaders,
+            ),
+        )
+    }
+}
+
+/**
+ * Metadata for feil som oppstår _før_ vi har gjort et reelt HTTP-forsøk (serialization-/validerings-feil).
+ * [HttpKlientMetadata] krever alle felter, så vi setter dem eksplisitt til "ikke utført": ingen response, 0 forsøk, ingen varigheter.
+ */
+private fun preFlightMetadata(
+    rawRequestString: String,
+    requestHeaders: Map<String, List<String>>,
+): HttpKlientMetadata = HttpKlientMetadata(
+    rawRequestString = rawRequestString,
+    rawResponseString = null,
+    requestHeaders = requestHeaders,
+    responseHeaders = emptyMap(),
+    statusCode = null,
+    attempts = 0,
+    attemptDurations = emptyList(),
+    totalDuration = ZERO,
+)
+
+internal fun HttpKlientRequest.rawRequestString(
+    requestHeaders: Map<String, List<String>>,
+    bodyAsString: String?,
+): String {
+    return buildString {
+        append(method.name)
+        append(" ")
+        append(uri)
+        requestHeaders.redactSensitiveHeaders().forEach { (name, values) ->
+            values.forEach { value ->
+                append("\n")
+                append(name)
+                append(": ")
+                append(value)
+            }
+        }
+        if (bodyAsString != null) {
+            append("\n\n")
+            append(bodyAsString)
+        }
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/InternalResponseConversion.kt
+++ b/httpklient/src/main/kotlin/httpklient/InternalResponseConversion.kt
@@ -1,0 +1,54 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import arrow.core.right
+import no.nav.tiltakspenger.libs.json.objectMapper
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
+
+internal fun <Response : Any> HttpKlientResponse<String>.deserializeBody(
+    responseType: KType,
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    return Either.catch {
+        val javaType = objectMapper.typeFactory.constructType(responseType.javaType)
+        @Suppress("UNCHECKED_CAST")
+        HttpKlientResponse(
+            statusCode = statusCode,
+            body = objectMapper.readValue<Any>(body, javaType) as Response,
+            metadata = metadata,
+        )
+    }.mapLeft { e ->
+        HttpKlientError.DeserializationError(
+            throwable = e,
+            body = body,
+            statusCode = statusCode,
+            metadata = metadata,
+        )
+    }
+}
+
+internal fun <Response : Any> HttpKlientResponse<String>.toTypedResponse(
+    responseType: KType,
+): Either<HttpKlientError, HttpKlientResponse<Response>> {
+    return when (responseType.classifier) {
+        String::class -> {
+            @Suppress("UNCHECKED_CAST")
+            HttpKlientResponse(
+                statusCode = statusCode,
+                body = body as Response,
+                metadata = metadata,
+            ).right()
+        }
+
+        Unit::class -> {
+            @Suppress("UNCHECKED_CAST")
+            HttpKlientResponse(
+                statusCode = statusCode,
+                body = Unit as Response,
+                metadata = metadata,
+            ).right()
+        }
+
+        else -> deserializeBody(responseType)
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/InternalThrowable.kt
+++ b/httpklient/src/main/kotlin/httpklient/InternalThrowable.kt
@@ -1,0 +1,26 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import no.nav.tiltakspenger.libs.httpklient.retry.AttemptOutcome
+import java.net.http.HttpTimeoutException
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+
+internal fun Throwable.toAttemptFailure(): AttemptOutcome.Failure {
+    return when (val unwrapped = unwrapCompletionException()) {
+        is HttpTimeoutException -> AttemptOutcome.Timeout(unwrapped)
+        else -> AttemptOutcome.NetworkError(unwrapped)
+    }
+}
+
+internal fun AttemptOutcome.Failure.toHttpKlientError(metadata: HttpKlientMetadata): HttpKlientError = when (this) {
+    is AttemptOutcome.Timeout -> HttpKlientError.Timeout(throwable = throwable, metadata = metadata)
+    is AttemptOutcome.NetworkError -> HttpKlientError.NetworkError(throwable = throwable, metadata = metadata)
+}
+
+private fun Throwable.unwrapCompletionException(): Throwable {
+    return when (this) {
+        is CompletionException -> cause?.unwrapCompletionException() ?: this
+        is ExecutionException -> cause?.unwrapCompletionException() ?: this
+        else -> this
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/JavaHttpKlient.kt
+++ b/httpklient/src/main/kotlin/httpklient/JavaHttpKlient.kt
@@ -1,0 +1,273 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import arrow.resilience.CircuitBreaker
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerCacheKey
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerDecisionContext
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.cacheKey
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.toCircuitBreaker
+import no.nav.tiltakspenger.libs.httpklient.retry.AttemptResult
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryExecutor
+import no.nav.tiltakspenger.libs.httpklient.retry.notifyExcessiveRetries
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KType
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+internal class JavaHttpKlient(
+    private val config: HttpKlient.HttpKlientConfig,
+    private val client: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(config.connectTimeout.toJavaDuration())
+        .followRedirects(config.followRedirects)
+        .build(),
+) : HttpKlient {
+    /**
+     * Cache av [CircuitBreaker]-instanser per [CircuitBreakerCacheKey] (dvs. per circuit breaker-`name`) for denne klienten.
+     * Entries opprettes lazily og fjernes aldri; én breaker beholdes for klientens levetid per distinkt `name`.
+     * `name` må derfor være lav-kardinalitet og stabil (f.eks. navnet på en nedstrøms-tjeneste) — ikke utledet fra noe høy-kardinalitet som host, tenant eller request-id, da vil mappet vokse ubegrenset.
+     * Den _første_ configen for et gitt `name` vinner: cachen nøkles kun på `name` (ikke på resetTimeout/strategy/callbacks/failurePredicate), så en senere request med samme `name` men annen config gjenbruker den eksisterende breakeren og den nye configen får ingen effekt.
+     * Dette er bevisst — breaker-_state_ må deles per `name` for å være meningsfull — men betyr at per-request-overstyringer av circuit breaker-config må holde `name` unikt per ønsket oppførsel.
+     */
+    private val circuitBreakers = ConcurrentHashMap<CircuitBreakerCacheKey, CircuitBreaker>()
+    override suspend fun <Response : Any> request(
+        request: HttpKlientRequest,
+        responseType: KType,
+    ): Either<HttpKlientError, HttpKlientResponse<Response>> {
+        return requestStringInternal(request).flatMap { response -> response.toTypedResponse(responseType) }
+    }
+
+    private suspend fun requestStringInternal(
+        request: HttpKlientRequest,
+    ): Either<HttpKlientError, HttpKlientResponse<String>> {
+        val loggingConfig = request.loggingConfig ?: config.logging
+        val retryConfig = request.retryConfig ?: config.defaultRetry
+        val circuitBreakerConfig = request.circuitBreakerConfig ?: config.defaultCircuitBreaker
+        val baseHeaders = request.headers
+        val authToken = resolveAuthToken(request, baseHeaders).getOrElse {
+            loggingConfig.logError(request, it)
+            return it.left()
+        }
+        val requestHeaders = if (authToken != null) baseHeaders.withBearerToken(authToken) else baseHeaders
+        val preparedRequest = request
+            .toJavaHttpRequest(config.defaultTimeout, requestHeaders)
+            .getOrElse {
+                // Pre-flight-feil (serialisering/ugyldig request) skal logges på lik linje med auth- og respons-feil, ikke bli stille.
+                loggingConfig.logError(request, it)
+                return it.left()
+            }
+
+        val effectiveSuccessStatus = request.successStatus ?: config.successStatus
+        val executeWithRetry = suspend {
+            val retryExecution = RetryExecutor(config.clock).execute(
+                request = request,
+                retryConfig = retryConfig,
+                isSuccessfulResponse = effectiveSuccessStatus,
+            ) { runSingleAttempt(preparedRequest.request) }
+            finalize(
+                request = request,
+                preparedRequest = preparedRequest,
+                requestHeaders = requestHeaders,
+                loggingConfig = loggingConfig,
+                retryConfig = retryConfig,
+                successStatusOverride = request.successStatus,
+                attempts = retryExecution.attempts,
+                attemptDurations = retryExecution.attemptDurations,
+                totalDuration = retryExecution.totalDuration,
+                lastResult = retryExecution.lastResult,
+            )
+        }
+        return when (circuitBreakerConfig) {
+            CircuitBreakerConfig.None -> executeWithRetry()
+
+            is CircuitBreakerConfig.Enabled -> executeWithCircuitBreaker(
+                request = request,
+                preparedRequest = preparedRequest,
+                requestHeaders = requestHeaders,
+                loggingConfig = loggingConfig,
+                circuitBreakerConfig = circuitBreakerConfig,
+                execute = executeWithRetry,
+            )
+        }
+    }
+
+    private suspend fun executeWithCircuitBreaker(
+        request: HttpKlientRequest,
+        preparedRequest: PreparedHttpKlientRequest,
+        requestHeaders: Map<String, List<String>>,
+        loggingConfig: HttpKlientLoggingConfig,
+        circuitBreakerConfig: CircuitBreakerConfig.Enabled,
+        execute: suspend () -> Either<HttpKlientError, HttpKlientResponse<String>>,
+    ): Either<HttpKlientError, HttpKlientResponse<String>> {
+        val circuitBreaker = circuitBreakers.computeIfAbsent(circuitBreakerConfig.cacheKey) {
+            circuitBreakerConfig.toCircuitBreaker()
+        }
+        return try {
+            circuitBreaker.protectEither {
+                execute().also { result ->
+                    result.mapLeft { error ->
+                        if (
+                            circuitBreakerConfig.failurePredicate(
+                                CircuitBreakerDecisionContext(request.method, request.uri, error),
+                            )
+                        ) {
+                            throw CircuitBreakerRecordedFailure(error)
+                        }
+                        error
+                    }
+                }
+            }.fold(
+                ifLeft = { rejected ->
+                    val error = HttpKlientError.CircuitBreakerOpen(
+                        throwable = rejected,
+                        metadata = HttpKlientMetadata(
+                            rawRequestString = preparedRequest.rawRequestString,
+                            rawResponseString = null,
+                            requestHeaders = requestHeaders,
+                            responseHeaders = emptyMap(),
+                            statusCode = null,
+                            attempts = 0,
+                            attemptDurations = emptyList(),
+                            totalDuration = Duration.ZERO,
+                        ),
+                    )
+                    loggingConfig.logError(request, error)
+                    error.left()
+                },
+                ifRight = { it },
+            )
+        } catch (e: CircuitBreakerRecordedFailure) {
+            e.error.left()
+        }
+    }
+
+    private suspend fun runSingleAttempt(request: java.net.http.HttpRequest): AttemptResult {
+        return Either.catch {
+            withContext(Dispatchers.IO) {
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
+            }
+        }.fold(
+            ifLeft = { AttemptResult.Failure(it.toAttemptFailure()) },
+            ifRight = { AttemptResult.Success(it) },
+        )
+    }
+
+    private fun finalize(
+        request: HttpKlientRequest,
+        preparedRequest: PreparedHttpKlientRequest,
+        requestHeaders: Map<String, List<String>>,
+        loggingConfig: HttpKlientLoggingConfig,
+        retryConfig: RetryConfig,
+        successStatusOverride: ((Int) -> Boolean)?,
+        attempts: Int,
+        attemptDurations: List<Duration>,
+        totalDuration: Duration,
+        lastResult: AttemptResult,
+    ): Either<HttpKlientError, HttpKlientResponse<String>> {
+        return when (lastResult) {
+            is AttemptResult.Failure -> {
+                val error = lastResult.failure.toHttpKlientError(
+                    metadata = HttpKlientMetadata(
+                        rawRequestString = preparedRequest.rawRequestString,
+                        rawResponseString = null,
+                        requestHeaders = requestHeaders,
+                        responseHeaders = emptyMap(),
+                        statusCode = null,
+                        attempts = attempts,
+                        attemptDurations = attemptDurations,
+                        totalDuration = totalDuration,
+                    ),
+                )
+                loggingConfig.logError(request, error)
+                retryConfig.notifyExcessiveRetries(attempts, totalDuration, attemptDurations, null, error)
+                error.left()
+            }
+
+            is AttemptResult.Success -> {
+                val response = lastResult.response
+                val responseBody = response.body()
+                val statusCode = response.statusCode()
+                val responseHeaders = response.headers().map()
+                val metadata = HttpKlientMetadata(
+                    rawRequestString = preparedRequest.rawRequestString,
+                    rawResponseString = responseBody,
+                    requestHeaders = requestHeaders,
+                    responseHeaders = responseHeaders,
+                    statusCode = statusCode,
+                    attempts = attempts,
+                    attemptDurations = attemptDurations,
+                    totalDuration = totalDuration,
+                )
+                if ((successStatusOverride ?: config.successStatus).invoke(statusCode)) {
+                    loggingConfig.logSuccess(request, statusCode, requestHeaders, responseHeaders)
+                    retryConfig.notifyExcessiveRetries(attempts, totalDuration, attemptDurations, statusCode, null)
+                    HttpKlientResponse<String>(
+                        statusCode = statusCode,
+                        body = responseBody,
+                        metadata = metadata,
+                    ).right()
+                } else {
+                    val error = HttpKlientError.UventetStatus(
+                        statusCode = statusCode,
+                        body = responseBody,
+                        metadata = metadata,
+                    )
+                    loggingConfig.logUventetStatus(request, error)
+                    retryConfig.notifyExcessiveRetries(attempts, totalDuration, attemptDurations, statusCode, error)
+                    error.left()
+                }
+            }
+        }
+    }
+
+    /**
+     * Returnerer per-request token, ellers henter via [HttpKlient.HttpKlientConfig.authTokenProvider] hvis satt.
+     * `Right(null)` betyr "ingen auth-header skal settes".
+     * `Left` returneres hvis provideren kaster.
+     */
+    private suspend fun resolveAuthToken(
+        request: HttpKlientRequest,
+        baseHeaders: Map<String, List<String>>,
+    ): Either<HttpKlientError.AuthError, AccessToken?> {
+        val perRequestToken = request.authToken
+        if (perRequestToken != null) return perRequestToken.right()
+        val provider = config.authTokenProvider ?: return null.right<AccessToken?>()
+        // Hvis konsumenten allerede har satt Authorization, hopp over provider for å unngå unødvendige token-kall.
+        if (baseHeaders.keys.any { it.equals("Authorization", ignoreCase = true) }) return null.right()
+        return Either.catch { provider() }.mapLeft { e ->
+            HttpKlientError.AuthError(
+                throwable = e,
+                metadata = HttpKlientMetadata(
+                    rawRequestString = request.rawRequestString(requestHeaders = baseHeaders, bodyAsString = null),
+                    rawResponseString = null,
+                    requestHeaders = baseHeaders,
+                    responseHeaders = emptyMap(),
+                    statusCode = null,
+                    attempts = 0,
+                    attemptDurations = emptyList(),
+                    totalDuration = Duration.ZERO,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Intern sentinel som gjør en `Either.Left` om til en exception mens Arrow `CircuitBreaker` beskytter blokken.
+     * Dette hviler på Arrow-kontrakten om at `protectEither` bare gjør `ExecutionRejected` om til `Either.Left`, og lar andre exceptions propagere etter at de er registrert som failures.
+     * Catch-blokken over fanger derfor eksplisitt bare denne typen for å mappe tilbake til den opprinnelige [HttpKlientError].
+     */
+    private class CircuitBreakerRecordedFailure(
+        val error: HttpKlientError,
+    ) : RuntimeException("HTTP-feil skal telle mot circuit breaker")
+}

--- a/httpklient/src/main/kotlin/httpklient/PreparedHttpKlientRequest.kt
+++ b/httpklient/src/main/kotlin/httpklient/PreparedHttpKlientRequest.kt
@@ -1,0 +1,8 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import java.net.http.HttpRequest
+
+internal data class PreparedHttpKlientRequest(
+    val request: HttpRequest,
+    val rawRequestString: String,
+)

--- a/httpklient/src/main/kotlin/httpklient/RequestBuilder.kt
+++ b/httpklient/src/main/kotlin/httpklient/RequestBuilder.kt
@@ -1,0 +1,191 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import kotlin.reflect.KType
+import kotlin.time.Duration
+
+class RequestBuilder(
+    val uri: URI,
+) {
+    var timeout: Duration? = null
+    var retryConfig: RetryConfig? = null
+    var circuitBreakerConfig: CircuitBreakerConfig? = null
+    var authToken: AccessToken? = null
+
+    private var successStatusOverride: ((Int) -> Boolean)? = null
+    private var loggingConfigOverride: HttpKlientLoggingConfig? = null
+
+    // Innsettingsordnet map fordi HttpKlientRequest-kontrakten lover at headere bevarer rekkefølgen konsumenten satte dem i, noe som gir forutsigbare logger/rawRequestString.
+    // Case-insensitivitet (RFC 9110 §5.1) håndteres i setHeader, som matcher eksisterende nøkkel uavhengig av casing i stedet for å sortere nøklene.
+    // Holdes som en uforanderlig Map som reassignes funksjonelt (jf. de øvrige builder-feltene) i stedet for å muteres på plass.
+    private var headers: Map<String, List<String>> = emptyMap()
+    private var requestBody: HttpKlientRequest.Body? = null
+
+    /**
+     * Setter [name] til [value] og fjerner eventuelle eksisterende verdier for samme nøkkel (samme semantikk som OkHttp `Request.Builder.header`).
+     * Bruk [addHeader] for å sende flere verdier på samme nøkkel.
+     *
+     * HTTP-headernavn er case-insensitive (RFC 9110 §5.1), så en eksisterende header med annen casing (f.eks. `X-Foo` vs `x-foo`) overskrives i stedet for å gi to separate headere i requesten.
+     */
+    fun header(name: String, value: String) {
+        setHeader(name, listOf(value))
+    }
+
+    /**
+     * Legger til en ekstra verdi for [name] uten å fjerne tidligere verdier (samme semantikk som OkHttp `Request.Builder.addHeader`).
+     * Brukes til multi-value-headere som `Accept-Encoding`, `Cookie`, `Set-Cookie`, etc.
+     *
+     * HTTP-headernavn er case-insensitive (RFC 9110 §5.1), så verdien legges til på en eventuell eksisterende header med annen casing (f.eks. `X-Foo` vs `x-foo`) i stedet for å opprette en duplikat-header.
+     */
+    fun addHeader(name: String, value: String) {
+        val eksisterendeVerdier = headers.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value ?: emptyList()
+        setHeader(name, eksisterendeVerdier + value)
+    }
+
+    /**
+     * Setter [name] til [values] og fjerner en eventuell eksisterende header med samme navn men annen casing (RFC 9110 §5.1).
+     * Casingen oppdateres alltid til den siste skriveren ([name]), slik at den nyeste [header]/[addHeader]-callen bestemmer hvordan navnet vises i logger/`rawRequestString`.
+     * Headerens opprinnelige posisjon i innsettingsrekkefølgen bevares når bare casingen endres.
+     */
+    private fun setHeader(name: String, values: List<String>) {
+        val eksisterendeNøkkel = headers.keys.firstOrNull { it.equals(name, ignoreCase = true) }
+        headers = when (eksisterendeNøkkel) {
+            // Ny header, eller samme casing som før: Map.plus legger til på slutten eller oppdaterer verdien på plass uten å endre rekkefølgen.
+            null, name -> headers + (name to values)
+
+            // Casingen er endret: map over entryene og bytt ut nøkkelen på samme posisjon, slik at den siste casingen vinner uten at headeren flyttes bakerst.
+            else -> headers.entries.associate { (nøkkel, gamleVerdier) ->
+                if (nøkkel == eksisterendeNøkkel) name to values else nøkkel to gamleVerdier
+            }
+        }
+    }
+
+    fun acceptJson() {
+        header("Accept", "application/json")
+    }
+
+    fun contentTypeJson() {
+        header("Content-Type", "application/json")
+    }
+
+    /** Overstyrer hvilke statuser som regnes som suksess for denne requesten. */
+    fun successStatus(predicate: (Int) -> Boolean) {
+        successStatusOverride = predicate
+    }
+
+    /** Som [successStatus], men godtar kun de eksplisitt oppgitte statuskodene (f.eks. `successStatus(200, 201)`). */
+    fun successStatus(vararg codes: Int) {
+        successStatus(HttpStatusSuccess.exactly(*codes))
+    }
+
+    /** Som [successStatus], men godtar alle statuskoder i [range] (f.eks. `successStatus(200..204)`). */
+    fun successStatus(range: IntRange) {
+        successStatus(HttpStatusSuccess.inRange(range))
+    }
+
+    fun logging(build: HttpKlientLoggingConfigBuilder.() -> Unit) {
+        loggingConfigOverride = HttpKlientLoggingConfig.build(build)
+    }
+
+    fun disableLogging() {
+        loggingConfigOverride = HttpKlientLoggingConfig.Disabled
+    }
+
+    /**
+     * Setter et bearer-token som vil bli sendt som `Authorization: Bearer <token>` på denne requesten.
+     * Overstyrer eventuell `authTokenProvider` på [HttpKlient].
+     * Konsumenter som allerede setter `Authorization` eksplisitt via [header]/[addHeader] vil få sin verdi beholdt uendret.
+     */
+    fun bearerToken(accessToken: AccessToken) {
+        authToken = accessToken
+    }
+
+    /**
+     * Sender bodyen som rå tekst uten å legge til JSON-headere automatisk.
+     * Bruk denne når payloaden ikke er JSON, eller når alle headere settes eksplisitt av konsumenten.
+     */
+    fun body(body: String) {
+        requestBody = HttpKlientRequest.Body.Raw(body)
+    }
+
+    /**
+     * Sender [fields] som `application/x-www-form-urlencoded` body.
+     * Nøkler og verdier URL-kodes (UTF-8), og `Content-Type: application/x-www-form-urlencoded` settes hvis den ikke allerede er satt case-insensitivt.
+     * Gjentatte nøkler bevares (f.eks. `formUrlEncoded("scope" to "a", "scope" to "b")` gir `scope=a&scope=b`), siden gjentatte felter er gyldige i form-encoding.
+     * Praktisk for token-endepunkter og andre legacy-API-er som forventer form-encoding i stedet for JSON.
+     */
+    fun formUrlEncoded(vararg fields: Pair<String, String>) {
+        formUrlEncodedFields(fields.asList())
+    }
+
+    /**
+     * Som [formUrlEncoded] med varargs, men tar et ferdig [felter]-Map.
+     * Merk at et `Map` ikke kan ha duplikate nøkler; bruk varargs-formen hvis du trenger gjentatte felter.
+     */
+    fun formUrlEncoded(felter: Map<String, String>) {
+        formUrlEncodedFields(felter.map { (name, value) -> name to value })
+    }
+
+    private fun formUrlEncodedFields(fields: List<Pair<String, String>>) {
+        val encoded = fields.joinToString("&") { (name, value) ->
+            "${URLEncoder.encode(name, StandardCharsets.UTF_8)}=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+        }
+        requestBody = HttpKlientRequest.Body.Raw(encoded)
+        if (headers.keys.none { it.equals("Content-Type", ignoreCase = true) }) {
+            header("Content-Type", "application/x-www-form-urlencoded")
+        }
+    }
+
+    /**
+     * Sender en ferdigserialisert JSON-string og legger til `Content-Type: application/json` hvis den ikke allerede er satt case-insensitivt.
+     *
+     * `Accept`-headeren styres bevisst _ikke_ herfra — den følger forventet response-type på `request<T>(...)`/verb-extensionene, som setter `Accept: application/json` automatisk for alle response-typer som ikke er `String` eller `Unit`.
+     */
+    fun json(body: String) {
+        requestBody = HttpKlientRequest.Body.RawJson(body)
+    }
+
+    /**
+     * Serialiserer DTO-en med `tiltakspenger-libs/json` og legger til `Content-Type: application/json` hvis den ikke allerede er satt case-insensitivt.
+     *
+     * `Accept`-headeren styres bevisst _ikke_ herfra — den følger forventet response-type på `request<T>(...)`/verb-extensionene, som setter `Accept: application/json` automatisk for alle response-typer som ikke er `String` eller `Unit`.
+     */
+    fun json(value: Any) {
+        requestBody = HttpKlientRequest.Body.Json(value)
+    }
+
+    /**
+     * Materialiserer builderen til en [HttpKlientRequest] som [HttpKlient.request] kan ta imot.
+     * Legger på klientens default-headere: `Accept: application/json` for [responseType] som ikke er `String`/`Unit`, og `Content-Type: application/json` for JSON-body — begge kun hvis de mangler (case-insensitivt).
+     *
+     * `@PublishedApi internal` fordi den kalles fra de public reified verb-extensionene (som er `inline`), men ikke skal være en del av det public API-et.
+     */
+    @PublishedApi
+    internal fun materialize(responseType: KType, method: HttpMethod): HttpKlientRequest {
+        val headersMedAccept = when (responseType.classifier) {
+            String::class, Unit::class -> headers.toMap()
+            else -> headers.withDefaultJsonAcceptHeader()
+        }
+        val headersMedContentType = when (requestBody) {
+            is HttpKlientRequest.Body.Json, is HttpKlientRequest.Body.RawJson -> headersMedAccept.withDefaultJsonContentTypeHeader()
+            else -> headersMedAccept
+        }
+        return HttpKlientRequest(
+            uri = uri,
+            method = method,
+            headers = headersMedContentType,
+            body = requestBody,
+            timeout = timeout,
+            authToken = authToken,
+            successStatus = successStatusOverride,
+            loggingConfig = loggingConfigOverride,
+            retryConfig = retryConfig,
+            circuitBreakerConfig = circuitBreakerConfig,
+        )
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/circuitbreaker/CircuitBreakerConfig.kt
+++ b/httpklient/src/main/kotlin/httpklient/circuitbreaker/CircuitBreakerConfig.kt
@@ -1,0 +1,209 @@
+package no.nav.tiltakspenger.libs.httpklient.circuitbreaker
+
+import arrow.resilience.CircuitBreaker
+import no.nav.tiltakspenger.libs.httpklient.HttpKlientError
+import no.nav.tiltakspenger.libs.httpklient.HttpMethod
+import java.net.URI
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * Predikat som avgjør om en ferdig HTTP-feil skal telle som circuit breaker-feil.
+ * Kalles etter eventuell retry, slik at circuit breakeren ser sluttresultatet for requesten.
+ */
+typealias CircuitBreakerPredicate = (CircuitBreakerDecisionContext) -> Boolean
+
+/** Kontekst som sendes til [CircuitBreakerPredicate]. */
+data class CircuitBreakerDecisionContext(
+    val method: HttpMethod,
+    val uri: URI,
+    val error: HttpKlientError,
+)
+
+/** Default predikat: tell bare forbigående/retryable feil mot circuit breakeren. */
+val CircuitBreakerOnRetryableErrors: CircuitBreakerPredicate = { ctx -> ctx.error.retryable }
+
+/** Predikat for konsumenter som vil skru av failure-recording uten å skru av configen. */
+val NeverRecordCircuitBreakerFailure: CircuitBreakerPredicate = { false }
+
+private val NoopCircuitBreakerCallback: suspend () -> Unit = {}
+
+/**
+ * Strategi for når circuit breakeren skal åpne.
+ * Bevisst tidskilde-fri: tidskilden settes ett sted ([CircuitBreakerConfig.Enabled.timeSource]) og bakes inn i Arrow-strategien først i [toCircuitBreaker].
+ * Da finnes det nøyaktig én tidskilde, og strategien kan aldri komme i utakt med breakerens tidskilde.
+ */
+sealed interface CircuitBreakerOpeningStrategy {
+    /** Åpner når [maxFailures] sammenhengende feil er registrert. */
+    data class Count(val maxFailures: Int) : CircuitBreakerOpeningStrategy
+
+    /** Åpner når [maxFailures] feil er registrert innenfor [windowDuration]. */
+    data class SlidingWindow(val maxFailures: Int, val windowDuration: Duration) : CircuitBreakerOpeningStrategy
+}
+
+/**
+ * Konfigurasjon for circuit breaker-logikk.
+ * Default [None] gjør ingenting.
+ *
+ * [Enabled] bygges normalt via [count] eller [slidingWindow].
+ * State ligger i hver [no.nav.tiltakspenger.libs.httpklient.HttpKlient]-instans, ikke statisk/globalt, og caches per [Enabled.name] for klientens levetid.
+ * [Enabled.name] må derfor være lav-kardinalitet og stabil (typisk navnet på en nedstrøms-tjeneste); ikke utled den fra host, tenant eller request-id.
+ *
+ * [Enabled] er bygget på Arrow Resilience sin [CircuitBreaker] og eksponerer bevisst [TimeSource] direkte.
+ * Det er akseptert her fordi alle konsumenter i teamet allerede bruker Arrow, og det gir tilgang til hele Arrow Resilience-konfigurasjonen uten et eget innpakningslag.
+ */
+sealed interface CircuitBreakerConfig {
+    data object None : CircuitBreakerConfig
+
+    data class Enabled(
+        /**
+         * Stabilt, lav-kardinalitet navn som identifiserer breaker-state innenfor én [no.nav.tiltakspenger.libs.httpklient.HttpKlient]-instans.
+         * Requests med samme navn deler breaker; instansen caches for klientens levetid, så ikke bruk høy-kardinalitet-verdier (host/tenant/request-id).
+         */
+        val name: String,
+        val resetTimeout: Duration,
+        val openingStrategy: CircuitBreakerOpeningStrategy,
+        val exponentialBackoffFactor: Double,
+        val maxResetTimeout: Duration,
+        /**
+         * Tidskilde for all circuit breaker-timing (reset-timeout og sliding window).
+         * Primært ment for deterministiske tester (f.eks. [kotlin.time.TestTimeSource]); bruk standarden [TimeSource.Monotonic] i produksjon.
+         */
+        val timeSource: TimeSource,
+        val failurePredicate: CircuitBreakerPredicate,
+        val onRejected: suspend () -> Unit,
+        val onClosed: suspend () -> Unit,
+        val onHalfOpen: suspend () -> Unit,
+        val onOpen: suspend () -> Unit,
+    ) : CircuitBreakerConfig {
+        init {
+            require(name.isNotBlank()) { "name kan ikke være blank" }
+            require(resetTimeout > Duration.ZERO) { "resetTimeout må være positiv, var $resetTimeout" }
+            require(exponentialBackoffFactor >= 1.0) {
+                "exponentialBackoffFactor må være >= 1.0, var $exponentialBackoffFactor"
+            }
+            require(maxResetTimeout >= resetTimeout) {
+                "maxResetTimeout ($maxResetTimeout) må være >= resetTimeout ($resetTimeout)"
+            }
+            // Enabled er public og kan instansieres direkte (også via copy), så strategien valideres her i stedet for kun i factory-metodene.
+            // Ugyldige verdier (f.eks. maxFailures = 0) ville ellers gitt negativ Arrow-konfig (maxFailures - 1) i toCircuitBreaker.
+            when (val strategy = openingStrategy) {
+                is CircuitBreakerOpeningStrategy.Count ->
+                    require(strategy.maxFailures > 0) { "maxFailures må være positiv, var ${strategy.maxFailures}" }
+
+                is CircuitBreakerOpeningStrategy.SlidingWindow -> {
+                    require(strategy.maxFailures > 0) { "maxFailures må være positiv, var ${strategy.maxFailures}" }
+                    require(strategy.windowDuration > Duration.ZERO) { "windowDuration må være positiv, var ${strategy.windowDuration}" }
+                }
+            }
+        }
+
+        fun withFailurePredicate(failurePredicate: CircuitBreakerPredicate): Enabled {
+            return copy(failurePredicate = failurePredicate)
+        }
+
+        fun withExponentialBackoff(
+            factor: Double,
+            maxResetTimeout: Duration = this.maxResetTimeout,
+        ): Enabled {
+            return copy(exponentialBackoffFactor = factor, maxResetTimeout = maxResetTimeout)
+        }
+
+        /** Bytter tidskilde; primært for deterministiske tester. */
+        fun withTimeSource(timeSource: TimeSource): Enabled {
+            return copy(timeSource = timeSource)
+        }
+
+        fun doOnRejectedTask(onRejected: suspend () -> Unit): Enabled {
+            return copy(onRejected = onRejected)
+        }
+
+        fun doOnClosed(onClosed: suspend () -> Unit): Enabled {
+            return copy(onClosed = onClosed)
+        }
+
+        fun doOnHalfOpen(onHalfOpen: suspend () -> Unit): Enabled {
+            return copy(onHalfOpen = onHalfOpen)
+        }
+
+        fun doOnOpen(onOpen: suspend () -> Unit): Enabled {
+            return copy(onOpen = onOpen)
+        }
+    }
+
+    companion object {
+        fun count(
+            name: String,
+            maxFailures: Int,
+            resetTimeout: Duration,
+            failurePredicate: CircuitBreakerPredicate = CircuitBreakerOnRetryableErrors,
+        ): Enabled {
+            // maxFailures valideres i Enabled.init, så vi unngår å duplisere require-en her.
+            return Enabled(
+                name = name,
+                resetTimeout = resetTimeout,
+                openingStrategy = CircuitBreakerOpeningStrategy.Count(maxFailures),
+                exponentialBackoffFactor = 1.0,
+                maxResetTimeout = resetTimeout,
+                timeSource = TimeSource.Monotonic,
+                failurePredicate = failurePredicate,
+                onRejected = NoopCircuitBreakerCallback,
+                onClosed = NoopCircuitBreakerCallback,
+                onHalfOpen = NoopCircuitBreakerCallback,
+                onOpen = NoopCircuitBreakerCallback,
+            )
+        }
+
+        fun slidingWindow(
+            name: String,
+            maxFailures: Int,
+            windowDuration: Duration,
+            resetTimeout: Duration,
+            failurePredicate: CircuitBreakerPredicate = CircuitBreakerOnRetryableErrors,
+        ): Enabled {
+            // maxFailures og windowDuration valideres i Enabled.init, så vi unngår å duplisere require-ene her.
+            return Enabled(
+                name = name,
+                resetTimeout = resetTimeout,
+                openingStrategy = CircuitBreakerOpeningStrategy.SlidingWindow(maxFailures, windowDuration),
+                exponentialBackoffFactor = 1.0,
+                maxResetTimeout = resetTimeout,
+                timeSource = TimeSource.Monotonic,
+                failurePredicate = failurePredicate,
+                onRejected = NoopCircuitBreakerCallback,
+                onClosed = NoopCircuitBreakerCallback,
+                onHalfOpen = NoopCircuitBreakerCallback,
+                onOpen = NoopCircuitBreakerCallback,
+            )
+        }
+    }
+}
+
+@JvmInline
+internal value class CircuitBreakerCacheKey(val name: String)
+
+internal val CircuitBreakerConfig.Enabled.cacheKey: CircuitBreakerCacheKey get() = CircuitBreakerCacheKey(name)
+
+internal fun CircuitBreakerConfig.Enabled.toCircuitBreaker(): CircuitBreaker {
+    val arrowOpeningStrategy = when (val strategy = openingStrategy) {
+        // Arrow teller "tillatte ekstra feil utover den første", så vi trekker fra 1 fra vår brukervendte maxFailures.
+        is CircuitBreakerOpeningStrategy.Count ->
+            CircuitBreaker.OpeningStrategy.Count(strategy.maxFailures - 1)
+
+        // Arrow lagrer en timeSource på SlidingWindow, men leser den aldri: selve vinduet timestampes via CircuitBreaker.timeSource (markNow() i trackFailure).
+        // Vi sender likevel inn vår [timeSource] her for å ikke etterlate en vilkårlig/avvikende verdi, og for å være robust mot framtidige Arrow-versjoner som måtte begynne å lese den.
+        is CircuitBreakerOpeningStrategy.SlidingWindow ->
+            CircuitBreaker.OpeningStrategy.SlidingWindow(timeSource, strategy.windowDuration, strategy.maxFailures - 1)
+    }
+    return CircuitBreaker(
+        resetTimeout = resetTimeout,
+        openingStrategy = arrowOpeningStrategy,
+        exponentialBackoffFactor = exponentialBackoffFactor,
+        maxResetTimeout = maxResetTimeout,
+        timeSource = timeSource,
+        onRejected = onRejected,
+        onClosed = onClosed,
+        onHalfOpen = onHalfOpen,
+        onOpen = onOpen,
+    )
+}

--- a/httpklient/src/main/kotlin/httpklient/retry/RetryConfig.kt
+++ b/httpklient/src/main/kotlin/httpklient/retry/RetryConfig.kt
@@ -1,0 +1,192 @@
+package no.nav.tiltakspenger.libs.httpklient.retry
+
+import arrow.resilience.Schedule
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.libs.httpklient.HttpKlientError
+import no.nav.tiltakspenger.libs.httpklient.HttpMethod
+import no.nav.tiltakspenger.libs.httpklient.isRetryableStatusCode
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+private val excessiveRetriesLogger = KotlinLogging.logger("no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig")
+
+/**
+ * Predikat som avgjør om et nytt forsøk skal gjøres etter siste utfall.
+ * Kalles _bare_ når outcome er retryable, og før [RetryConfig.schedule] spørres om retry-budsjett.
+ */
+typealias RetryPredicate = (RetryDecisionContext) -> Boolean
+
+/**
+ * Konfigurasjon for retry-logikk.
+ * Retry-loopen styres av en Arrow [Schedule] som bestemmer timing (backoff) og antall retries; vår kode kort-slutter på [AttemptOutcome.retryable] og konsulterer [retryOn] før schedulen får ordet.
+ *
+ * Default ([None]) gir _ingen_ retries, bakover-kompatibelt med klienter som ikke aktiverer retry.
+ *
+ * [retryOn] defaulter til [NeverRetry]; en bar `RetryConfig(schedule = ...)` retry-er altså ikke før du eksplisitt setter et predikat (f.eks. [RetryOnServerErrorsAndNetwork]).
+ * Fabrikkene [exponential] og [fixed] defaulter derimot til [RetryOnServerErrorsAndNetwork], siden det å velge en av dem allerede uttrykker eksplisitt retry-intensjon.
+ *
+ * @property schedule Arrow [Schedule] som styrer ventetid mellom forsøk og maks antall retries.
+ * @property retryOn Domene-predikat som typisk sjekker HTTP-metode-idempotens og lignende.
+ * @property excessiveRetriesThreshold Hvis satt og `attempts - 1 >= terskel`, kalles [onExcessiveRetries] etter at requesten er ferdig.
+ */
+data class RetryConfig(
+    val schedule: Schedule<AttemptOutcome, *>,
+    val retryOn: RetryPredicate = NeverRetry,
+    val excessiveRetriesThreshold: Int? = null,
+    val onExcessiveRetries: (RetryOutcome) -> Unit = ::defaultLogExcessiveRetries,
+) {
+    init {
+        excessiveRetriesThreshold?.let {
+            require(it >= 1) { "excessiveRetriesThreshold må være minst 1 (terskelen telles i antall retries), var $it" }
+        }
+    }
+
+    /**
+     * Fluent variant for å bytte retry-predikat uten å måtte bruke `copy(...)` i konsumentkode.
+     */
+    fun withRetryOn(retryOn: RetryPredicate): RetryConfig {
+        return copy(retryOn = retryOn)
+    }
+
+    /**
+     * Slår på varsling når antall retries (`attempts - 1`) er minst [threshold].
+     */
+    fun notifyOnExcessiveRetries(
+        threshold: Int,
+        onExcessiveRetries: (RetryOutcome) -> Unit = this.onExcessiveRetries,
+    ): RetryConfig {
+        return copy(
+            excessiveRetriesThreshold = threshold,
+            onExcessiveRetries = onExcessiveRetries,
+        )
+    }
+
+    /**
+     * Slår av excessive-retry-varsling uten å endre schedule eller retry-predikat.
+     */
+    fun withoutExcessiveRetriesNotification(): RetryConfig {
+        return copy(excessiveRetriesThreshold = null)
+    }
+
+    companion object {
+        /** Ingen retries — default. */
+        val None: RetryConfig = RetryConfig(schedule = Schedule.recurs(0L), retryOn = NeverRetry)
+
+        /**
+         * Eksponentiell backoff med valgfri jitter, opp til [maxRetries] retries.
+         * Bygger `Schedule.exponential(initialDelay)`, legger på valgfri moderat symmetrisk jitter (`0.5..1.5`), og capper deretter resultatet hardt på [maxDelay] — jitter kan altså aldri presse en ventetid over [maxDelay].
+         * Dette er ikke full jitter / maksimal dekorrelasjon; konsumenter som trenger AWS-aktig full jitter kan sende inn en egen Arrow [Schedule] direkte.
+         * Kombineres med `Schedule.recurs(maxRetries)` via `zipLeft` (dvs. behold delay-output, stopp så snart en av de to schedulene sier Done).
+         */
+        fun exponential(
+            maxRetries: Int,
+            initialDelay: Duration = 200.milliseconds,
+            maxDelay: Duration = 5.seconds,
+            jitter: Boolean = true,
+            retryOn: RetryPredicate = RetryOnServerErrorsAndNetwork,
+            random: Random = Random.Default,
+        ): RetryConfig {
+            require(maxRetries >= 0) { "maxRetries kan ikke være negativ, var $maxRetries" }
+            require(initialDelay >= Duration.ZERO) { "initialDelay kan ikke være negativ, var $initialDelay" }
+            require(maxDelay >= initialDelay) { "maxDelay ($maxDelay) må være >= initialDelay ($initialDelay)" }
+            val base: Schedule<AttemptOutcome, Duration> =
+                Schedule.exponential<AttemptOutcome>(initialDelay)
+            val withJitter: Schedule<AttemptOutcome, Duration> =
+                if (jitter) base.jittered(0.5, 1.5, random) else base
+            // Cappes til slutt slik at [maxDelay] er et hardt tak også med jitter.
+            val capped: Schedule<AttemptOutcome, Duration> =
+                withJitter.delayed { _, d -> d.coerceAtMost(maxDelay) }
+            val limited: Schedule<AttemptOutcome, *> =
+                capped.zipLeft(Schedule.recurs(maxRetries.toLong()))
+            return RetryConfig(schedule = limited, retryOn = retryOn)
+        }
+
+        /** Konstant backoff opp til [maxRetries] retries. */
+        fun fixed(
+            maxRetries: Int,
+            delay: Duration,
+            retryOn: RetryPredicate = RetryOnServerErrorsAndNetwork,
+        ): RetryConfig {
+            require(maxRetries >= 0) { "maxRetries kan ikke være negativ, var $maxRetries" }
+            require(delay >= Duration.ZERO) { "delay kan ikke være negativ, var $delay" }
+            val schedule: Schedule<AttemptOutcome, *> =
+                Schedule.spaced<AttemptOutcome>(delay)
+                    .zipLeft(Schedule.recurs(maxRetries.toLong()))
+            return RetryConfig(schedule = schedule, retryOn = retryOn)
+        }
+    }
+}
+
+/** Default predikat: aldri retry. Konsumenter må eksplisitt si hva som skal retry-es. */
+val NeverRetry: RetryPredicate = { false }
+
+/**
+ * Praktisk default-predikat: tillater retry _kun_ for idempotente HTTP-metoder (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`).
+ * Følger RFC 7231 §4.2.2 og er på linje med Failsafe sin idempotent-default.
+ * Hvilke utfall som er retry-bare (`408`/`425`/`429`/`500`/`502`/`503`/`504`/`Timeout`/`NetworkError`) avgjøres av [AttemptOutcome.retryable].
+ */
+val RetryOnServerErrorsAndNetwork: RetryPredicate = { ctx -> ctx.method.isIdempotent() }
+
+fun HttpMethod.isIdempotent(): Boolean = when (this) {
+    HttpMethod.GET, HttpMethod.HEAD, HttpMethod.OPTIONS, HttpMethod.PUT, HttpMethod.DELETE -> true
+    HttpMethod.POST, HttpMethod.PATCH -> false
+}
+
+/**
+ * Kontekst som sendes til [RetryPredicate] etter hvert forsøk.
+ *
+ * @property method HTTP-metoden for requesten.
+ * @property attemptNumber Forsøket som akkurat ble fullført (1-basert).
+ * @property outcome Utfallet av forsøket.
+ */
+data class RetryDecisionContext(
+    val method: HttpMethod,
+    val attemptNumber: Int,
+    val outcome: AttemptOutcome,
+)
+
+sealed interface AttemptOutcome {
+    /**
+     * `true` hvis utfallet i seg selv kan tenkes å gi et annet resultat ved nytt forsøk.
+     * Brukes av retry-loopen som en hard gate — selv om [RetryConfig.retryOn] sier "ja", vil loopen aldri retry-e et utfall der `retryable = false`.
+     */
+    val retryable: Boolean
+
+    /** HTTP-respons mottatt med [statusCode]. */
+    data class Status(val statusCode: Int) : AttemptOutcome {
+        override val retryable: Boolean get() = isRetryableStatusCode(statusCode)
+    }
+
+    /** Forsøket fullførte ikke med en HTTP-respons (nettverksfeil, timeout, osv.). */
+    sealed interface Failure : AttemptOutcome {
+        val throwable: Throwable
+    }
+
+    /** Forsøket time-et ut (request- eller connect-timeout). */
+    data class Timeout(override val throwable: Throwable) : Failure {
+        override val retryable: Boolean get() = true
+    }
+
+    /** Andre nettverks-/IO-feil. */
+    data class NetworkError(override val throwable: Throwable) : Failure {
+        override val retryable: Boolean get() = true
+    }
+}
+
+/** Sammenfatning av retry-forbruket etter at requesten er ferdig (uansett utfall). */
+data class RetryOutcome(
+    val attempts: Int,
+    val totalDuration: Duration,
+    val attemptDurations: List<Duration>,
+    val finalStatusCode: Int?,
+    val finalError: HttpKlientError?,
+)
+
+internal fun defaultLogExcessiveRetries(outcome: RetryOutcome) {
+    excessiveRetriesLogger.warn {
+        "HTTP-klient brukte ${outcome.attempts} forsøk (totalt ${outcome.totalDuration}). " +
+            "Vurder å øke timeout eller undersøke nedstrømsstabilitet."
+    }
+}

--- a/httpklient/src/main/kotlin/httpklient/retry/RetryExecutor.kt
+++ b/httpklient/src/main/kotlin/httpklient/retry/RetryExecutor.kt
@@ -1,0 +1,102 @@
+package no.nav.tiltakspenger.libs.httpklient.retry
+
+import arrow.resilience.Schedule
+import kotlinx.coroutines.delay
+import no.nav.tiltakspenger.libs.httpklient.HttpKlientError
+import no.nav.tiltakspenger.libs.httpklient.HttpKlientRequest
+import java.time.Clock
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+import java.time.Duration as JavaDuration
+
+internal data class RetryExecutionResult(
+    val lastResult: AttemptResult,
+    val attempts: Int,
+    val attemptDurations: List<Duration>,
+    val totalDuration: Duration,
+)
+
+internal sealed interface AttemptResult {
+    data class Success(val response: java.net.http.HttpResponse<String>) : AttemptResult
+    data class Failure(val failure: AttemptOutcome.Failure) : AttemptResult
+}
+
+internal fun AttemptResult.toAttemptOutcome(): AttemptOutcome = when (this) {
+    is AttemptResult.Success -> AttemptOutcome.Status(response.statusCode())
+    is AttemptResult.Failure -> failure
+}
+
+internal class RetryExecutor(
+    private val clock: Clock,
+) {
+    /**
+     * Kjører [attempt] minst én gang og bruker [retryConfig] sin Arrow [Schedule] til å avgjøre ventetid og retry-budsjett.
+     * [AttemptOutcome.retryable] og [RetryConfig.retryOn] er harde gates før schedulen spørres, slik at utfall som ikke faktisk retry-es ikke bruker retry-budsjett.
+     * [isSuccessfulResponse] er det effektive `successStatus`-predikatet for requesten; en respons som allerede regnes som suksess retry-es aldri, selv om statuskoden ligger i den retryable mengden (f.eks. en konsument som godtar `503` som suksess).
+     */
+    suspend fun execute(
+        request: HttpKlientRequest,
+        retryConfig: RetryConfig,
+        isSuccessfulResponse: (Int) -> Boolean,
+        attempt: suspend () -> AttemptResult,
+    ): RetryExecutionResult {
+        val attemptDurations = mutableListOf<Duration>()
+        val totalStart = clock.instant()
+        var attemptNumber = 0
+        var lastResult: AttemptResult
+        var scheduleStep: suspend (AttemptOutcome) -> Schedule.Decision<AttemptOutcome, *> =
+            retryConfig.schedule::invoke
+
+        while (true) {
+            attemptNumber++
+            val attemptStart = clock.instant()
+            lastResult = attempt()
+            val attemptDuration = JavaDuration.between(attemptStart, clock.instant()).toKotlinDuration()
+            attemptDurations += attemptDuration
+
+            val outcome = lastResult.toAttemptOutcome()
+            if (outcome is AttemptOutcome.Status && isSuccessfulResponse(outcome.statusCode)) break
+            if (!outcome.retryable) break
+            if (!retryConfig.retryOn(RetryDecisionContext(request.method, attemptNumber, outcome))) break
+
+            when (val decision = scheduleStep(outcome)) {
+                is Schedule.Decision.Done -> break
+
+                is Schedule.Decision.Continue -> {
+                    if (decision.delay > Duration.ZERO) {
+                        delay(decision.delay)
+                    }
+                    scheduleStep = decision.step
+                }
+            }
+        }
+
+        return RetryExecutionResult(
+            lastResult = lastResult,
+            attempts = attemptNumber,
+            attemptDurations = attemptDurations.toList(),
+            totalDuration = JavaDuration.between(totalStart, clock.instant()).toKotlinDuration(),
+        )
+    }
+}
+
+internal fun RetryConfig.notifyExcessiveRetries(
+    attempts: Int,
+    totalDuration: Duration,
+    attemptDurations: List<Duration>,
+    finalStatusCode: Int?,
+    finalError: HttpKlientError?,
+) {
+    val threshold = excessiveRetriesThreshold ?: return
+    val retriesUsed = (attempts - 1).coerceAtLeast(0)
+    if (retriesUsed < threshold) return
+    onExcessiveRetries(
+        RetryOutcome(
+            attempts = attempts,
+            totalDuration = totalDuration,
+            attemptDurations = attemptDurations,
+            finalStatusCode = finalStatusCode,
+            finalError = finalError,
+        ),
+    )
+}

--- a/httpklient/src/test/kotlin/httpklient/CircuitBreakerConfigTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/CircuitBreakerConfigTest.kt
@@ -1,0 +1,76 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerOpeningStrategy
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+import kotlin.time.TimeSource
+
+internal class CircuitBreakerConfigTest {
+    @Test
+    fun `slidingWindow lagrer en tidskilde-fri strategi med brukervendt maxFailures`() {
+        val config = CircuitBreakerConfig.slidingWindow(
+            name = "test",
+            maxFailures = 3,
+            windowDuration = 10.seconds,
+            resetTimeout = 5.seconds,
+        )
+
+        val slidingWindow = config.openingStrategy.shouldBeInstanceOf<CircuitBreakerOpeningStrategy.SlidingWindow>()
+        slidingWindow.maxFailures shouldBe 3
+        slidingWindow.windowDuration shouldBe 10.seconds
+    }
+
+    @Test
+    fun `count lagrer en tidskilde-fri strategi med brukervendt maxFailures`() {
+        val config = CircuitBreakerConfig.count(
+            name = "test",
+            maxFailures = 3,
+            resetTimeout = 5.seconds,
+        )
+
+        config.openingStrategy.shouldBeInstanceOf<CircuitBreakerOpeningStrategy.Count>().maxFailures shouldBe 3
+    }
+
+    @Test
+    fun `withTimeSource bytter kun tidskilde og lar strategien stå uendret`() {
+        val customTimeSource: TimeSource = TestTimeSource()
+        val config = CircuitBreakerConfig.slidingWindow(
+            name = "test",
+            maxFailures = 3,
+            windowDuration = 10.seconds,
+            resetTimeout = 5.seconds,
+        ).withTimeSource(customTimeSource)
+
+        config.timeSource shouldBe customTimeSource
+        // Strategien er tidskilde-fri, så den er uberørt av byttet — det finnes kun én tidskilde.
+        config.openingStrategy shouldBe CircuitBreakerOpeningStrategy.SlidingWindow(maxFailures = 3, windowDuration = 10.seconds)
+    }
+
+    @Test
+    fun `Enabled validerer Count-strategien direkte i init`() {
+        // Enabled er public, så en direkte konstruksjon (her via copy) med ugyldig maxFailures må avvises i init, ikke bare i factory-metodene.
+        val gyldig = CircuitBreakerConfig.count(name = "test", maxFailures = 2, resetTimeout = 5.seconds)
+
+        shouldThrowWithMessage<IllegalArgumentException>("maxFailures må være positiv, var 0") {
+            gyldig.copy(openingStrategy = CircuitBreakerOpeningStrategy.Count(maxFailures = 0))
+        }
+    }
+
+    @Test
+    fun `Enabled validerer SlidingWindow-strategien direkte i init`() {
+        val gyldig = CircuitBreakerConfig.slidingWindow(name = "test", maxFailures = 2, windowDuration = 10.seconds, resetTimeout = 5.seconds)
+
+        shouldThrowWithMessage<IllegalArgumentException>("maxFailures må være positiv, var 0") {
+            gyldig.copy(openingStrategy = CircuitBreakerOpeningStrategy.SlidingWindow(maxFailures = 0, windowDuration = 10.seconds))
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("windowDuration må være positiv, var 0s") {
+            gyldig.copy(openingStrategy = CircuitBreakerOpeningStrategy.SlidingWindow(maxFailures = 2, windowDuration = ZERO))
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientAuthTokenTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientAuthTokenTest.kt
@@ -1,0 +1,120 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+internal class HttpKlientAuthTokenTest {
+    @Test
+    fun `bearer-token sendes ekte til serveren men maskeres i metadata`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/redaksjon")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/redaksjon")) {
+                bearerToken(testAccessToken("hemmelig-token"))
+            }.getOrFail()
+
+            // Serveren mottar det ekte tokenet.
+            wiremock.verify(getRequestedFor(urlEqualTo("/redaksjon")).withHeader("Authorization", equalTo("Bearer hemmelig-token")))
+            // Men rawRequestString (som ofte logges) maskerer det.
+            response.metadata.rawRequestString.shouldNotContain("hemmelig-token")
+            response.metadata.rawRequestString.shouldContain("Authorization: ***")
+        }
+    }
+
+    @Test
+    fun `authTokenProvider gir Bearer-header på hver request`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/a")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            var calls = 0
+            val klient = HttpKlient(clock = fixedClock) {
+                authTokenProvider = {
+                    calls++
+                    testAccessToken("tok-$calls")
+                }
+            }
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/a")).getOrFail()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/a")).getOrFail()
+
+            wiremock.verify(getRequestedFor(urlEqualTo("/a")).withHeader("Authorization", equalTo("Bearer tok-1")))
+            wiremock.verify(getRequestedFor(urlEqualTo("/a")).withHeader("Authorization", equalTo("Bearer tok-2")))
+            calls shouldBe 2
+        }
+    }
+
+    @Test
+    fun `per-request bearerToken overstyrer klient-default`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/b")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = HttpKlient(clock = fixedClock) {
+                authTokenProvider = { error("provider skal ikke kalles når request setter token") }
+            }
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/b")) {
+                bearerToken(testAccessToken("override"))
+            }.getOrFail()
+
+            wiremock.verify(getRequestedFor(urlEqualTo("/b")).withHeader("Authorization", equalTo("Bearer override")))
+        }
+    }
+
+    @Test
+    fun `eksplisitt Authorization-header beholdes uendret`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/c")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = HttpKlient(clock = fixedClock) {
+                authTokenProvider = { error("provider skal ikke kalles når Authorization er satt") }
+            }
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/c")) {
+                header("Authorization", "Basic abc")
+            }.getOrFail()
+
+            wiremock.verify(getRequestedFor(urlEqualTo("/c")).withHeader("Authorization", equalTo("Basic abc")))
+        }
+    }
+
+    @Test
+    fun `ingen authTokenProvider gir ingen Authorization-header`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/d")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/d")).getOrFail()
+
+            // wiremock vil reportere request uten Authorization-header — sjekk at ingen var sendt.
+            wiremock.findAll(getRequestedFor(urlEqualTo("/d"))).single().header("Authorization").isPresent shouldBe false
+        }
+    }
+
+    @Test
+    fun `authTokenProvider som kaster gir AuthError uten HTTP-kall`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/e")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = HttpKlient(clock = fixedClock) {
+                authTokenProvider = { throw IllegalStateException("token-endepunkt nede") }
+            }
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/e")).swap().getOrNull()!!
+
+            val authError = error.shouldBeInstanceOf<HttpKlientError.AuthError>()
+            authError.throwable.message shouldBe "token-endepunkt nede"
+            authError.retryable shouldBe false
+            authError.metadata.attempts shouldBe 0
+            wiremock.findAll(getRequestedFor(urlEqualTo("/e"))).size shouldBe 0
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientCircuitBreakerTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientCircuitBreakerTest.kt
@@ -1,0 +1,528 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerDecisionContext
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerOnRetryableErrors
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerOpeningStrategy
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerPredicate
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.NeverRecordCircuitBreakerFailure
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryOnServerErrorsAndNetwork
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TestTimeSource
+
+internal class HttpKlientCircuitBreakerTest {
+
+    @Test
+    fun `default CircuitBreakerConfig gjør ingenting`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/default")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(circuitBreakerConfig = CircuitBreakerConfig.None)
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/default"))
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/default"))
+
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/default")))
+        }
+    }
+
+    @Test
+    fun `åpner etter konfigurert antall retryable feil og avviser uten nytt HTTP-kall`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/ustabil")).willReturn(aResponse().withStatus(503).withBody("nei")))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "ustabil",
+                    maxFailures = 2,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/ustabil")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/ustabil")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            val rejected = klient.get<String>(URI.create("${wiremock.baseUrl()}/ustabil")).swap().getOrNull()!!
+
+            val circuitBreakerOpen = rejected.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            circuitBreakerOpen.retryable shouldBe false
+            circuitBreakerOpen.metadata.attempts shouldBe 0
+            circuitBreakerOpen.metadata.attemptDurations.shouldBeEmpty()
+            circuitBreakerOpen.metadata.statusCode shouldBe null
+            circuitBreakerOpen.metadata.rawRequestString shouldBe "GET ${wiremock.baseUrl()}/ustabil"
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/ustabil")))
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `resetter etter resetTimeout og lukker ved vellykket half-open kall`() = runTest {
+        val timeSource = TestTimeSource()
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/kommer-seg"))
+                    .inScenario("circuit-reset").whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(aResponse().withStatus(503))
+                    .willSetStateTo("ok"),
+            )
+            wiremock.stubFor(
+                get(urlEqualTo("/kommer-seg"))
+                    .inScenario("circuit-reset").whenScenarioStateIs("ok")
+                    .willReturn(aResponse().withStatus(200).withBody("frisk")),
+            )
+            var halfOpen = 0
+            var closed = 0
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "kommer-seg",
+                    maxFailures = 1,
+                    resetTimeout = 10.milliseconds,
+                ).withTimeSource(timeSource)
+                    .doOnHalfOpen { halfOpen++ }
+                    .doOnClosed { closed++ },
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/kommer-seg")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/kommer-seg")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            timeSource += 11.milliseconds
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/kommer-seg")).getOrFail()
+
+            response.body shouldBe "frisk"
+            halfOpen shouldBe 1
+            closed shouldBe 1
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/kommer-seg")))
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `feiler half-open kall åpner breakeren igjen og avviser neste kall uten HTTP`() = runTest {
+        val timeSource = TestTimeSource()
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/fortsatt-syk")).willReturn(aResponse().withStatus(503)))
+            var halfOpen = 0
+            var open = 0
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "fortsatt-syk",
+                    maxFailures = 1,
+                    resetTimeout = 10.milliseconds,
+                ).withTimeSource(timeSource)
+                    .doOnHalfOpen { halfOpen++ }
+                    .doOnOpen { open++ },
+            )
+
+            // Første feil åpner breakeren.
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fortsatt-syk")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fortsatt-syk")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+
+            // Etter reset slipper half-open ett prøvekall gjennom — som også feiler, så breakeren åpner igjen.
+            timeSource += 11.milliseconds
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fortsatt-syk")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            // Neste kall avvises igjen uten nytt HTTP-kall.
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fortsatt-syk")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+
+            halfOpen shouldBe 1
+            open shouldBe 2
+            // Kun det første kallet og half-open-prøvekallet traff serveren.
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/fortsatt-syk")))
+        }
+    }
+
+    @Test
+    fun `circuit breaker state er lokal per navn innenfor samme klient`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/tjeneste-a")).willReturn(aResponse().withStatus(503)))
+            wiremock.stubFor(get(urlEqualTo("/tjeneste-b")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient()
+
+            // Åpner breakeren for navnet "a".
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/tjeneste-a")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count("a", maxFailures = 1, resetTimeout = 100.milliseconds)
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/tjeneste-a")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count("a", maxFailures = 1, resetTimeout = 100.milliseconds)
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+
+            // Navnet "b" er upåvirket og slipper fortsatt HTTP-kallet gjennom.
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/tjeneste-b")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count("b", maxFailures = 1, resetTimeout = 100.milliseconds)
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/tjeneste-a")))
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/tjeneste-b")))
+        }
+    }
+
+    @Test
+    fun `count maxFailures 1 åpner etter første registrerte feil`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/count-off-by-one")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "count-off-by-one",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/count-off-by-one")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            val rejected = klient.get<String>(URI.create("${wiremock.baseUrl()}/count-off-by-one")).swap().getOrNull()!!
+
+            rejected.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/count-off-by-one")))
+        }
+    }
+
+    @Test
+    fun `slidingWindow maxFailures 1 åpner etter første registrerte feil`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/sliding-off-by-one")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.slidingWindow(
+                    name = "sliding-off-by-one",
+                    maxFailures = 1,
+                    windowDuration = 100.milliseconds,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/sliding-off-by-one")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            val rejected = klient.get<String>(URI.create("${wiremock.baseUrl()}/sliding-off-by-one")).swap().getOrNull()!!
+
+            rejected.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/sliding-off-by-one")))
+        }
+    }
+
+    @Test
+    fun `circuit breaker state er lokal per JavaHttpKlient-instans`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/lokal")).willReturn(aResponse().withStatus(503)))
+            val config = CircuitBreakerConfig.count(
+                name = "lokal",
+                maxFailures = 1,
+                resetTimeout = 100.milliseconds,
+            )
+            val klient1 = testHttpKlient(circuitBreakerConfig = config)
+            val klient2 = testHttpKlient(circuitBreakerConfig = config)
+
+            klient1.get<String>(URI.create("${wiremock.baseUrl()}/lokal")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient1.get<String>(URI.create("${wiremock.baseUrl()}/lokal")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            klient2.get<String>(URI.create("${wiremock.baseUrl()}/lokal")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/lokal")))
+        }
+    }
+
+    @Test
+    fun `per-request circuitBreakerConfig overstyrer klient-default`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/override")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(circuitBreakerConfig = CircuitBreakerConfig.None)
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/override")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "override",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ).withFailurePredicate { ctx -> ctx.error.retryable }
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            val rejected = klient.get<String>(URI.create("${wiremock.baseUrl()}/override")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "override",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ).withFailurePredicate { ctx -> ctx.error.retryable }
+            }.swap().getOrNull()!!
+
+            rejected.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/override")))
+        }
+    }
+
+    @Test
+    fun `inline per-request configs med nye lambdaer deler breaker via navn`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/inline-lambdaer")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(circuitBreakerConfig = CircuitBreakerConfig.None)
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/inline-lambdaer")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "inline-lambdaer",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ).withFailurePredicate { ctx -> ctx.error.retryable }
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            val rejected = klient.get<String>(URI.create("${wiremock.baseUrl()}/inline-lambdaer")) {
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "inline-lambdaer",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ).withFailurePredicate { ctx -> ctx.error.retryable }
+            }.swap().getOrNull()!!
+
+            rejected.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>()
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/inline-lambdaer")))
+        }
+    }
+
+    @Test
+    fun `circuit breaker teller sluttresultat etter retry`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/retry-og-circuit")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig.fixed(
+                    maxRetries = 1,
+                    delay = ZERO,
+                    retryOn = RetryOnServerErrorsAndNetwork,
+                ),
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "retry-og-circuit",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            val first = klient.get<String>(URI.create("${wiremock.baseUrl()}/retry-og-circuit")).swap().getOrNull()!!
+            val second = klient.get<String>(URI.create("${wiremock.baseUrl()}/retry-og-circuit")).swap().getOrNull()!!
+
+            first.shouldBeInstanceOf<HttpKlientError.UventetStatus>().metadata.attempts shouldBe 2
+            second.shouldBeInstanceOf<HttpKlientError.CircuitBreakerOpen>().metadata.attempts shouldBe 0
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/retry-og-circuit")))
+        }
+    }
+
+    @Test
+    fun `failurePredicate styrer hva som teller mot circuit breaker`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/fire-null-fire")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "fire-null-fire",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                )
+                    .withFailurePredicate(NeverRecordCircuitBreakerFailure),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fire-null-fire")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/fire-null-fire")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            wiremock.verify(2, getRequestedFor(urlEqualTo("/fire-null-fire")))
+        }
+    }
+
+    @Test
+    fun `callbacks for open og rejected kalles`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/callbacks")).willReturn(aResponse().withStatus(503)))
+            var open = 0
+            var rejected = 0
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "callbacks",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                )
+                    .doOnOpen { open++ }
+                    .doOnRejectedTask { rejected++ },
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/callbacks"))
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/callbacks"))
+
+            open shouldBe 1
+            rejected shouldBe 1
+        }
+    }
+
+    @Test
+    fun `ikke-sentinel exception fra protectEither-blokken propagerer`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/predicate-kaster")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "predicate-kaster",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ).withFailurePredicate { error("predikat-feil") },
+            )
+
+            shouldThrowWithMessage<IllegalStateException>("predikat-feil") {
+                klient.get<String>(URI.create("${wiremock.baseUrl()}/predicate-kaster"))
+            }
+        }
+    }
+
+    @Test
+    fun `CircuitBreakerConfig fluent helpers oppdaterer kun relevante felter`() {
+        val failurePredicate: CircuitBreakerPredicate = { false }
+        val onRejected: suspend () -> Unit = {}
+        val onClosed: suspend () -> Unit = {}
+        val onHalfOpen: suspend () -> Unit = {}
+        val onOpen: suspend () -> Unit = {}
+        val config = CircuitBreakerConfig.count(name = "fluent", maxFailures = 2, resetTimeout = 100.milliseconds)
+            .withFailurePredicate(failurePredicate)
+            .withExponentialBackoff(factor = 2.0, maxResetTimeout = 1_000.milliseconds)
+            .doOnRejectedTask(onRejected)
+            .doOnClosed(onClosed)
+            .doOnHalfOpen(onHalfOpen)
+            .doOnOpen(onOpen)
+
+        config.failurePredicate shouldBe failurePredicate
+        config.exponentialBackoffFactor shouldBe 2.0
+        config.maxResetTimeout shouldBe 1_000.milliseconds
+        config.onRejected shouldBe onRejected
+        config.onClosed shouldBe onClosed
+        config.onHalfOpen shouldBe onHalfOpen
+        config.onOpen shouldBe onOpen
+    }
+
+    @Test
+    fun `CircuitBreakerConfig factories og validering`() {
+        CircuitBreakerConfig.count(name = "count", maxFailures = 1, resetTimeout = 1.milliseconds)
+            .openingStrategy.shouldBeInstanceOf<CircuitBreakerOpeningStrategy.Count>()
+        CircuitBreakerConfig.slidingWindow(
+            name = "sliding",
+            maxFailures = 2,
+            windowDuration = 10.milliseconds,
+            resetTimeout = 1.milliseconds,
+        ).openingStrategy.shouldBeInstanceOf<CircuitBreakerOpeningStrategy.SlidingWindow>()
+        CircuitBreakerOnRetryableErrors(
+            CircuitBreakerDecisionContext(HttpMethod.GET, URI.create("http://localhost"), HttpKlientError.UventetStatus(503, "", tomMetadata())),
+        ) shouldBe true
+        CircuitBreakerOnRetryableErrors(
+            CircuitBreakerDecisionContext(HttpMethod.GET, URI.create("http://localhost"), HttpKlientError.UventetStatus(404, "", tomMetadata())),
+        ) shouldBe false
+        NeverRecordCircuitBreakerFailure(
+            CircuitBreakerDecisionContext(HttpMethod.GET, URI.create("http://localhost"), HttpKlientError.UventetStatus(503, "", tomMetadata())),
+        ) shouldBe false
+
+        shouldThrowWithMessage<IllegalArgumentException>("name kan ikke være blank") {
+            CircuitBreakerConfig.count(name = " ", maxFailures = 1, resetTimeout = 1.milliseconds)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("maxFailures må være positiv, var 0") {
+            CircuitBreakerConfig.count(name = "invalid-count", maxFailures = 0, resetTimeout = 1.milliseconds)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("maxFailures må være positiv, var 0") {
+            CircuitBreakerConfig.slidingWindow(
+                name = "invalid-sliding",
+                maxFailures = 0,
+                windowDuration = 1.milliseconds,
+                resetTimeout = 1.milliseconds,
+            )
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("windowDuration må være positiv, var 0s") {
+            CircuitBreakerConfig.slidingWindow(
+                name = "invalid-window",
+                maxFailures = 1,
+                windowDuration = ZERO,
+                resetTimeout = 1.milliseconds,
+            )
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("resetTimeout må være positiv, var 0s") {
+            CircuitBreakerConfig.count(name = "invalid-reset", maxFailures = 1, resetTimeout = ZERO)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("exponentialBackoffFactor må være >= 1.0, var 0.9") {
+            CircuitBreakerConfig.count(name = "invalid-factor", maxFailures = 1, resetTimeout = 1.milliseconds)
+                .withExponentialBackoff(factor = 0.9)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("maxResetTimeout (1ms) må være >= resetTimeout (2ms)") {
+            CircuitBreakerConfig.count(name = "invalid-max-reset", maxFailures = 1, resetTimeout = 2.milliseconds)
+                .withExponentialBackoff(factor = 1.0, maxResetTimeout = 1.milliseconds)
+        }
+    }
+
+    @Test
+    fun `HttpKlientError CircuitBreakerOpen har retryable false`() {
+        val rejected = arrow.resilience.CircuitBreaker.ExecutionRejected(
+            "open",
+            arrow.resilience.CircuitBreaker.State.Closed(
+                arrow.resilience.CircuitBreaker.OpeningStrategy.Count(1),
+            ),
+        )
+
+        HttpKlientError.CircuitBreakerOpen(rejected, tomMetadata()).retryable shouldBe false
+    }
+
+    @Test
+    fun `ikke-retryable status (404) åpner ikke breakeren med default-predikat`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/fire-null-fire-default")).willReturn(aResponse().withStatus(404)))
+            val klient = testHttpKlient(
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "fnf-default",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            // Default-predikatet teller bare retryable feil; 404 er permanent, så breakeren forblir lukket og alle tre kallene treffer serveren.
+            repeat(3) {
+                klient.get<String>(URI.create("${wiremock.baseUrl()}/fire-null-fire-default")).swap().getOrNull()!!
+                    .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            }
+
+            wiremock.verify(3, getRequestedFor(urlEqualTo("/fire-null-fire-default")))
+        }
+    }
+
+    @Test
+    fun `forbigående feil som lykkes via retry holder breakeren lukket`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/transient")).inScenario("forb").whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(aResponse().withStatus(503))
+                    .willSetStateTo("ok"),
+            )
+            wiremock.stubFor(
+                get(urlEqualTo("/transient")).inScenario("forb").whenScenarioStateIs("ok")
+                    .willReturn(aResponse().withStatus(200).withBody("oppe")),
+            )
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig.fixed(maxRetries = 1, delay = ZERO, retryOn = RetryOnServerErrorsAndNetwork),
+                circuitBreakerConfig = CircuitBreakerConfig.count(
+                    name = "forb",
+                    maxFailures = 1,
+                    resetTimeout = 100.milliseconds,
+                ),
+            )
+
+            // Første kall feiler én gang (503) og lykkes på retry; sluttresultatet er suksess, så breakeren registrerer ingen feil.
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/transient")).getOrFail().body shouldBe "oppe"
+            // Breakeren er fortsatt lukket, så neste kall går rett gjennom.
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/transient")).getOrFail().body shouldBe "oppe"
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientConcurrencyTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientConcurrencyTest.kt
@@ -1,0 +1,48 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+internal class HttpKlientConcurrencyTest {
+    @Test
+    fun `samme HttpKlient-instans kan brukes fra mange coroutines parallelt`() {
+        val antallRequests = 50
+        runBlocking {
+            withWireMock { wiremock ->
+                repeat(antallRequests) { i ->
+                    wiremock.stubFor(
+                        get(urlEqualTo("/parallell/$i")).willReturn(
+                            aResponse().withStatus(200).withBody("svar-$i"),
+                        ),
+                    )
+                }
+                val klient = testHttpKlient(connectTimeout = 5.seconds, timeout = 5.seconds)
+                val antallFullfort = AtomicInteger(0)
+
+                val resultater = withContext(Dispatchers.IO) {
+                    (0 until antallRequests).map { i ->
+                        async {
+                            klient.get<String>(URI.create("${wiremock.baseUrl()}/parallell/$i")).getOrFail().body
+                                .also { antallFullfort.incrementAndGet() }
+                        }
+                    }.awaitAll()
+                }
+
+                antallFullfort.get() shouldBe antallRequests
+                resultater shouldBe (0 until antallRequests).map { "svar-$it" }
+            }
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientConvenienceAccessorsTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientConvenienceAccessorsTest.kt
@@ -1,0 +1,56 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+internal class HttpKlientConvenienceAccessorsTest {
+    private val metadata = HttpKlientMetadata(
+        rawRequestString = "GET https://example.com/api",
+        rawResponseString = "respons-body",
+        requestHeaders = mapOf("Accept" to listOf("application/json")),
+        responseHeaders = mapOf("Content-Type" to listOf("application/json")),
+        statusCode = 503,
+        attempts = 3,
+        attemptDurations = listOf(100.milliseconds, 200.milliseconds, 700.milliseconds),
+        totalDuration = 1.seconds,
+    )
+
+    @Test
+    fun `HttpKlientError eksponerer metadata-feltene via convenience-aksessorer`() {
+        val error: HttpKlientError = HttpKlientError.Timeout(throwable = RuntimeException("timeout"), metadata = metadata)
+
+        error.rawRequestString shouldBe metadata.rawRequestString
+        error.rawResponseString shouldBe metadata.rawResponseString
+        error.requestHeaders shouldBe metadata.requestHeaders
+        error.responseHeaders shouldBe metadata.responseHeaders
+        error.attempts shouldBe metadata.attempts
+        error.attemptDurations shouldBe metadata.attemptDurations
+        error.totalDuration shouldBe metadata.totalDuration
+    }
+
+    @Test
+    fun `HttpKlientResponse eksponerer metadata-feltene via convenience-aksessorer`() {
+        val response = HttpKlientResponse(statusCode = 200, body = "body", metadata = metadata)
+
+        response.rawRequestString shouldBe metadata.rawRequestString
+        response.rawResponseString shouldBe metadata.rawResponseString
+        response.requestHeaders shouldBe metadata.requestHeaders
+        response.responseHeaders shouldBe metadata.responseHeaders
+        response.attempts shouldBe metadata.attempts
+        response.attemptDurations shouldBe metadata.attemptDurations
+        response.totalDuration shouldBe metadata.totalDuration
+    }
+
+    @Test
+    fun `RequestBuilder eksponerer authToken som er satt`() {
+        val token = testAccessToken("token-123")
+        val builder = RequestBuilder(URI.create("https://example.com/api")).apply {
+            bearerToken(token)
+        }
+
+        builder.authToken shouldBe token
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientDefaultHeadersTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientDefaultHeadersTest.kt
@@ -1,0 +1,60 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+/**
+ * Karakteriserer hvem som "eier" headerne: vi setter et subset, mens `java.net.http.HttpClient` legger på sine egne transport-headere (Host, User-Agent, Content-Length) ved sending.
+ * Vi fjerner dem aldri — de når serveren — men de finnes bevisst _ikke_ i [HttpKlientMetadata.requestHeaders]/`rawRequestString`.
+ * Grunnen er en bevisst begrensning, ikke en forglemmelse: JDK legger dem på i det ikke-offentlige connection-laget, og `HttpRequest.headers()` eksponerer dem ikke (verifisert), så vi kan verken lese dem tilbake fra klienten eller speile dem uten å reimplementere JDK-intern oppførsel (som ville bundet oss til Java-versjonen).
+ */
+internal class HttpKlientDefaultHeadersTest {
+    @Test
+    fun `java-klienten legger på transport-headere som når serveren uten at vi fjerner dem`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/defaults")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/defaults"), """{"a":1}""") {
+                header("X-Consumer", "satt-av-oss")
+            }.getOrFail().body shouldBe "ok"
+
+            // Det serveren faktisk mottok på wire: JDK legger på transport-headere vi aldri satte, og vi fjerner dem ikke.
+            val mottatt = wiremock.findAll(postRequestedFor(urlEqualTo("/defaults"))).single()
+            mottatt.containsHeader("User-Agent") shouldBe true
+            mottatt.getHeader("User-Agent") shouldContain "Java-http-client"
+            mottatt.containsHeader("Host") shouldBe true
+            mottatt.containsHeader("Content-Length") shouldBe true
+            mottatt.getHeader("X-Consumer") shouldBe "satt-av-oss"
+            mottatt.getHeader("Content-Type") shouldBe "application/json"
+        }
+    }
+
+    @Test
+    fun `metadata inneholder headerne vi setter, men ikke JDK-ens transport-headere som ikke kan leses tilbake`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/metadata")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val metadata = klient.post<String>(URI.create("${wiremock.baseUrl()}/metadata"), """{"a":1}""") {
+                header("X-Consumer", "satt-av-oss")
+            }.getOrFail().metadata
+
+            // Headerne vi selv setter (konsument + klient-defaults) er med.
+            metadata.requestHeader("X-Consumer") shouldBe "satt-av-oss"
+            metadata.requestHeader("Content-Type") shouldBe "application/json"
+            // JDK-ens transport-headere er bevisst fraværende: de eksponeres ikke av java.net.http, så vi kan ikke speile dem uten å reimplementere JDK-intern oppførsel. Dokumentert på HttpKlientMetadata.requestHeaders.
+            metadata.requestHeader("Host") shouldBe null
+            metadata.requestHeader("User-Agent") shouldBe null
+            metadata.requestHeader("Content-Length") shouldBe null
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientDefaultsTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientDefaultsTest.kt
@@ -1,0 +1,103 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import no.nav.tiltakspenger.libs.common.fixedClock
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.reflect.typeOf
+
+internal class HttpKlientDefaultsTest {
+    @Test
+    fun `kan opprette klient med default timeouts`() {
+        HttpKlient(clock = fixedClock).shouldBeInstanceOf<HttpKlient>()
+    }
+
+    @Test
+    fun `HttpKlient-factoryen returnerer en HttpKlient`() {
+        val klient: HttpKlient = HttpKlient(clock = fixedClock)
+
+        klient.shouldBeInstanceOf<HttpKlient>()
+    }
+
+    @Test
+    fun `request builder eksponerer nullable overrides`() {
+        val materialized = RequestBuilder(URI.create("http://localhost/test")).materialize(typeOf<String>(), HttpMethod.GET)
+
+        materialized.successStatus shouldBe null
+        materialized.loggingConfig shouldBe null
+        materialized.authToken shouldBe null
+    }
+
+    @Test
+    fun `request builder kan materialisere requesten`() {
+        val request = RequestBuilder(URI.create("http://localhost/test"))
+            .apply {
+                addHeader("X-Test", "1")
+                json("{}")
+                bearerToken(testAccessToken("token"))
+            }.materialize(typeOf<String>(), HttpMethod.POST)
+
+        request.uri shouldBe URI.create("http://localhost/test")
+        request.method shouldBe HttpMethod.POST
+        request.headers["X-Test"] shouldBe listOf("1")
+        request.headers["Accept"] shouldBe null
+        request.headers["Content-Type"] shouldBe listOf("application/json")
+        request.body shouldBe HttpKlientRequest.Body.RawJson("{}")
+        request.timeout shouldBe null
+        request.authToken shouldBe testAccessToken("token")
+    }
+
+    @Test
+    fun `HttpStatusSuccess is2xx returnerer true for 2xx og false ellers`() {
+        HttpStatusSuccess.is2xx(199) shouldBe false
+        HttpStatusSuccess.is2xx(200) shouldBe true
+        HttpStatusSuccess.is2xx(299) shouldBe true
+        HttpStatusSuccess.is2xx(300) shouldBe false
+        HttpStatusSuccess.is2xx(404) shouldBe false
+        HttpStatusSuccess.is2xx(500) shouldBe false
+    }
+
+    @Test
+    fun `HttpStatusSuccess exactly godtar kun oppgitte koder`() {
+        val predicate = HttpStatusSuccess.exactly(200, 201, 204)
+        predicate(200) shouldBe true
+        predicate(201) shouldBe true
+        predicate(204) shouldBe true
+        predicate(202) shouldBe false
+        predicate(404) shouldBe false
+    }
+
+    @Test
+    fun `HttpStatusSuccess exactly krever minst en kode`() {
+        shouldThrow<IllegalArgumentException> { HttpStatusSuccess.exactly() }
+    }
+
+    @Test
+    fun `HttpStatusSuccess inRange godtar koder i intervallet`() {
+        val predicate = HttpStatusSuccess.inRange(200..204)
+        predicate(199) shouldBe false
+        predicate(200) shouldBe true
+        predicate(204) shouldBe true
+        predicate(205) shouldBe false
+    }
+
+    @Test
+    fun `RequestBuilder successStatus vararg-overload bygger exactly-predikat`() {
+        val builder = RequestBuilder(URI.create("http://localhost/test")).apply { successStatus(201, 202) }
+        val predicate = builder.materialize(typeOf<String>(), HttpMethod.GET).successStatus!!
+        predicate(201) shouldBe true
+        predicate(202) shouldBe true
+        predicate(200) shouldBe false
+    }
+
+    @Test
+    fun `RequestBuilder successStatus range-overload bygger inRange-predikat`() {
+        val builder = RequestBuilder(URI.create("http://localhost/test")).apply { successStatus(200..204) }
+        val predicate = builder.materialize(typeOf<String>(), HttpMethod.GET).successStatus!!
+        predicate(200) shouldBe true
+        predicate(204) shouldBe true
+        predicate(205) shouldBe false
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientErrorTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientErrorTest.kt
@@ -1,0 +1,175 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.UniformDistribution
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class HttpKlientErrorTest {
+    @Test
+    fun `returnerer UventetStatus ved status som ikke godtas av successStatus`() = runTest {
+        // Java-trigger: HttpResponse med statusCode som default successStatus (is2xx) forkaster.
+        // Ingen exception — feilen utledes av selve statuskoden i finalize().
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/feil")).willReturn(aResponse().withStatus(500).withBody("feil")),
+            )
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/feil")) {
+                header("X-Trace-Id", "trace-feil")
+            }.swap().getOrNull()!!
+
+            val ikke2xx = error.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            ikke2xx.statusCode shouldBe 500
+            ikke2xx.body shouldBe "feil"
+            ikke2xx.metadata.requestHeaders["X-Trace-Id"] shouldBe listOf("trace-feil")
+            ikke2xx.metadata.statusCode shouldBe 500
+            ikke2xx.metadata.rawResponseString shouldBe "feil"
+            ikke2xx.metadata.rawRequestString shouldBe """GET ${wiremock.baseUrl()}/feil
+                |X-Trace-Id: trace-feil
+            """.trimMargin()
+        }
+    }
+
+    @Test
+    fun `returnerer SerializationError ved request-dto som ikke kan serialiseres`() = runTest {
+        // Java-trigger: Jackson kaster ved serialize() av en selvrefererende DTO (StackOverflow/InvalidDefinitionException), før noen HttpRequest bygges.
+        val klient = testHttpKlient()
+
+        val error = klient.post<String>(URI.create("http://localhost/skal-ikke-kalles")) {
+            header("X-Test", "serialisering")
+            json(SelvRefererendeDto())
+        }.swap().getOrNull()!!
+
+        val serializationError = error.shouldBeInstanceOf<HttpKlientError.SerializationError>()
+        serializationError.metadata.requestHeaders["X-Test"] shouldBe listOf("serialisering")
+        serializationError.metadata.requestHeaders["Accept"] shouldBe null
+        serializationError.metadata.requestHeaders["Content-Type"] shouldBe listOf("application/json")
+        serializationError.metadata.rawRequestString shouldBe """POST http://localhost/skal-ikke-kalles
+            |X-Test: serialisering
+            |Content-Type: application/json
+            |
+            |<json-serialisering feilet>
+        """.trimMargin()
+        serializationError.metadata.rawResponseString shouldBe null
+    }
+
+    @Test
+    fun `returnerer DeserializationError ved ugyldig json i vellykket respons`() = runTest {
+        // Java-trigger: 200-respons godtas av successStatus, men objectMapper.readValue kaster når body ikke kan parses til måltypen.
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/ugyldig-json")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("ikke-json"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val error = klient.get<TestResponseDto>(URI.create("${wiremock.baseUrl()}/ugyldig-json")).swap().getOrNull()!!
+
+            val deserializationError = error.shouldBeInstanceOf<HttpKlientError.DeserializationError>()
+            deserializationError.body shouldBe "ikke-json"
+            deserializationError.statusCode shouldBe 200
+            deserializationError.metadata.rawResponseString shouldBe "ikke-json"
+            deserializationError.metadata.statusCode shouldBe 200
+            deserializationError.metadata.requestHeaders["Accept"] shouldBe listOf("application/json")
+        }
+    }
+
+    @Test
+    fun `returnerer Timeout ved request-timeout`() = runTest {
+        // Java-trigger: sendAsync fullfører med java.net.http.HttpTimeoutException når serverens delay overstiger request-timeouten.
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/treg")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(500)
+                        .withBody("ok"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/treg")) {
+                timeout = 50.milliseconds
+            }.swap().getOrNull()!!
+
+            val timeout = error.shouldBeInstanceOf<HttpKlientError.Timeout>()
+            timeout.metadata.rawRequestString shouldBe "GET ${wiremock.baseUrl()}/treg"
+            timeout.metadata.rawResponseString shouldBe null
+        }
+    }
+
+    @Test
+    fun `returnerer Timeout ved varierende latens fra UniformDistribution`() = runTest {
+        // Verifiserer at timeout-håndtering fungerer selv når serverens delay varierer (mer realistisk simulering av faktisk nettverksstøy enn fast withFixedDelay).
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/jitter")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withRandomDelay(UniformDistribution(400, 600))
+                        .withBody("ok"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/jitter")) {
+                timeout = 50.milliseconds
+            }.swap().getOrNull()!!
+
+            error.shouldBeInstanceOf<HttpKlientError.Timeout>()
+        }
+    }
+
+    @Test
+    fun `returnerer InvalidRequest ved ugyldig header`() = runTest {
+        // Java-trigger: HttpRequest.Builder.header(...) kaster IllegalArgumentException for et ulovlig headernavn, fanget i toJavaHttpRequest().
+        val klient = testHttpKlient()
+
+        val error = klient.get<String>(URI.create("http://localhost/ugyldig")) {
+            header("Ugyldig Header", "verdi")
+        }.swap().getOrNull()!!
+
+        val invalidRequest = error.shouldBeInstanceOf<HttpKlientError.InvalidRequest>()
+        invalidRequest.metadata.requestHeaders["Ugyldig Header"] shouldBe listOf("verdi")
+        invalidRequest.metadata.rawRequestString shouldBe """GET http://localhost/ugyldig
+            |Ugyldig Header: verdi
+        """.trimMargin()
+    }
+
+    @Test
+    fun `returnerer InvalidRequest ved ugyldig uri-scheme`() = runTest {
+        // Java-trigger: JDK-klienten (HttpRequest.Builder.uri) avviser scheme som ikke er http/https med IllegalArgumentException, som mappes til InvalidRequest.
+        val klient = testHttpKlient()
+
+        val error = klient.get<String>(URI.create("ftp://localhost/ugyldig")).swap().getOrNull()!!
+
+        error.shouldBeInstanceOf<HttpKlientError.InvalidRequest>()
+    }
+
+    @Test
+    fun `tom body med DTO-type gir DeserializationError`() = runTest {
+        // Java-trigger: 200 godtas av successStatus, men objectMapper.readValue kaster «No content to map» når bodyen er tom.
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/tom-body")).willReturn(aResponse().withStatus(200)))
+            val klient = testHttpKlient()
+
+            val error = klient.get<TestResponseDto>(URI.create("${wiremock.baseUrl()}/tom-body")).swap().getOrNull()!!
+
+            val deserializationError = error.shouldBeInstanceOf<HttpKlientError.DeserializationError>()
+            deserializationError.statusCode shouldBe 200
+            deserializationError.body shouldBe ""
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientFaultTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientFaultTest.kt
@@ -1,0 +1,88 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.Fault
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+internal class HttpKlientFaultTest {
+    @Test
+    fun `returnerer NetworkError når server ikke kan kontaktes`() = runTest {
+        val uri = stoppedServerUri("/stoppet")
+        val klient = testHttpKlient()
+
+        val error = klient.get<String>(uri).swap().getOrNull()!!
+
+        val networkError = error.shouldBeInstanceOf<HttpKlientError.NetworkError>()
+        networkError.metadata.rawRequestString shouldBe "GET $uri"
+        networkError.metadata.statusCode shouldBe null
+    }
+
+    @Test
+    fun `returnerer NetworkError ved CONNECTION_RESET_BY_PEER`() = runTest {
+        assertFaultGirNetworkError(Fault.CONNECTION_RESET_BY_PEER, "/reset")
+    }
+
+    @Test
+    fun `returnerer NetworkError ved EMPTY_RESPONSE`() = runTest {
+        assertFaultGirNetworkError(Fault.EMPTY_RESPONSE, "/empty")
+    }
+
+    @Test
+    fun `returnerer NetworkError ved MALFORMED_RESPONSE_CHUNK`() = runTest {
+        assertFaultGirNetworkError(Fault.MALFORMED_RESPONSE_CHUNK, "/malformed")
+    }
+
+    @Test
+    fun `returnerer NetworkError ved RANDOM_DATA_THEN_CLOSE`() = runTest {
+        assertFaultGirNetworkError(Fault.RANDOM_DATA_THEN_CLOSE, "/random")
+    }
+
+    @Test
+    fun `propagerer CancellationException når coroutine kanselleres under request`() {
+        // Vi må bruke runBlocking (ikke runTest) for å få ekte tid og cancellation propagering gjennom Dispatchers.IO.
+        // wiremock holder responsen i 2 sekunder, vi kansellerer etter 100ms.
+        runBlocking {
+            withWireMock { wiremock ->
+                wiremock.stubFor(
+                    get(urlEqualTo("/slow")).willReturn(aResponse().withStatus(200).withFixedDelay(2_000).withBody("aldri")),
+                )
+                val klient = testHttpKlient(timeout = 5.seconds)
+
+                val deferred = async(Dispatchers.IO) {
+                    klient.get<String>(URI.create("${wiremock.baseUrl()}/slow"))
+                }
+                delay(100)
+                deferred.cancel(CancellationException("test"))
+
+                shouldThrow<CancellationException> {
+                    deferred.await()
+                }
+            }
+        }
+    }
+}
+
+private suspend fun assertFaultGirNetworkError(fault: Fault, path: String) {
+    withWireMock { wiremock ->
+        wiremock.stubFor(get(urlEqualTo(path)).willReturn(aResponse().withFault(fault)))
+        val klient = testHttpKlient(timeout = 1_000.milliseconds)
+
+        val error = klient.get<String>(URI.create("${wiremock.baseUrl()}$path")).swap().getOrNull()!!
+
+        error.shouldBeInstanceOf<HttpKlientError.NetworkError>()
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientGetTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientGetTest.kt
@@ -1,0 +1,190 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.delete
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.head
+import com.github.tomakehurst.wiremock.client.WireMock.options
+import com.github.tomakehurst.wiremock.client.WireMock.patch
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.put
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+internal class HttpKlientGetTest {
+    @Test
+    fun `uri-scheme er case-insensitivt (RFC 3986) og store bokstaver godtas`() = runTest {
+        // RFC 3986 §3.1: scheme er case-insensitivt. JDK-klienten lowercaser scheme selv, så HTTP:// skal fungere som http://.
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/store-scheme")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val uppercaseScheme = wiremock.baseUrl().replaceFirst("http://", "HTTP://")
+            klient.get<String>(URI.create("$uppercaseScheme/store-scheme")).getOrFail().body shouldBe "ok"
+        }
+    }
+
+    @Test
+    fun `request og post kan brukes uten builder`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/default-request")).willReturn(aResponse().withStatus(200).withBody("default-request")))
+            wiremock.stubFor(post(urlEqualTo("/default-post")).willReturn(aResponse().withStatus(200).withBody("default-post")))
+            val klient = testHttpKlient()
+
+            klient.request<String>(URI.create("${wiremock.baseUrl()}/default-request"), HttpMethod.GET).getOrFail().body shouldBe "default-request"
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/default-post")).getOrFail().body shouldBe "default-post"
+        }
+    }
+
+    @Test
+    fun `request builder sender GET og deserialiserer response-dto`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/bruker")).withHeader("X-Trace-Id", equalTo("trace-1")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"ok","antall":1}"""),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.request<TestResponseDto>(URI.create("${wiremock.baseUrl()}/bruker"), HttpMethod.GET) {
+                header("X-Trace-Id", "trace-1")
+                timeout = 250.milliseconds
+            }.getOrFail()
+
+            response.statusCode shouldBe 200
+            response.body shouldBe TestResponseDto(status = "ok", antall = 1)
+            response.metadata.requestHeaders["Accept"] shouldBe listOf("application/json")
+            response.metadata.requestHeaders["X-Trace-Id"] shouldBe listOf("trace-1")
+            response.metadata.statusCode shouldBe 200
+            response.metadata.rawResponseString shouldBe """{"status":"ok","antall":1}"""
+            response.metadata.rawRequestString shouldBe """GET ${wiremock.baseUrl()}/bruker
+                |X-Trace-Id: trace-1
+                |Accept: application/json
+            """.trimMargin()
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/bruker"))
+                    .withHeader("Accept", equalTo("application/json"))
+                    .withHeader("X-Trace-Id", equalTo("trace-1")),
+            )
+        }
+    }
+
+    @Test
+    fun `verb helpers setter riktig http method`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/get")).willReturn(aResponse().withStatus(200).withBody("get")))
+            wiremock.stubFor(put(urlEqualTo("/put")).willReturn(aResponse().withStatus(200).withBody("put")))
+            wiremock.stubFor(patch(urlEqualTo("/patch")).willReturn(aResponse().withStatus(200).withBody("patch")))
+            wiremock.stubFor(delete(urlEqualTo("/delete")).willReturn(aResponse().withStatus(200).withBody("delete")))
+            wiremock.stubFor(head(urlEqualTo("/head")).willReturn(aResponse().withStatus(204).withHeader("X-Head", "ok")))
+            wiremock.stubFor(options(urlEqualTo("/options")).willReturn(aResponse().withStatus(200).withBody("options")))
+            val klient = testHttpKlient()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/get")).getOrFail().body shouldBe "get"
+            klient.put<String>(URI.create("${wiremock.baseUrl()}/put")).getOrFail().body shouldBe "put"
+            klient.patch<String>(URI.create("${wiremock.baseUrl()}/patch")).getOrFail().body shouldBe "patch"
+            klient.delete<String>(URI.create("${wiremock.baseUrl()}/delete")).getOrFail().body shouldBe "delete"
+            klient.head<Unit>(URI.create("${wiremock.baseUrl()}/head")).getOrFail().metadata.responseHeaders["X-Head"] shouldBe listOf("ok")
+            klient.options<String>(URI.create("${wiremock.baseUrl()}/options")).getOrFail().body shouldBe "options"
+        }
+    }
+
+    @Test
+    fun `kan konfigurere success status globalt`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/accepted")).willReturn(aResponse().withStatus(202).withBody("accepted")))
+            val klient = testHttpKlient(successStatus = { it == 202 })
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/accepted")).getOrFail().body shouldBe "accepted"
+        }
+    }
+
+    @Test
+    fun `kan overstyre success status per request`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/not-modified")).willReturn(aResponse().withStatus(304).withBody("")))
+            val klient = testHttpKlient()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/not-modified")) {
+                successStatus { it == 304 }
+            }.getOrFail().statusCode shouldBe 304
+        }
+    }
+
+    @Test
+    fun `kan deserialisere generiske response-typer som List Set og Map`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/list")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""[{"status":"ok","antall":1},{"status":"feil","antall":2}]"""),
+                ),
+            )
+            wiremock.stubFor(
+                get(urlEqualTo("/set")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""[{"status":"ok","antall":1},{"status":"feil","antall":2}]"""),
+                ),
+            )
+            wiremock.stubFor(
+                get(urlEqualTo("/map")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"a":{"status":"ok","antall":1},"b":{"status":"feil","antall":2}}"""),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val list = klient.get<List<TestResponseDto>>(URI.create("${wiremock.baseUrl()}/list")).getOrFail()
+            list.body shouldBe listOf(
+                TestResponseDto(status = "ok", antall = 1),
+                TestResponseDto(status = "feil", antall = 2),
+            )
+            // Tving en faktisk feltbruk — hvis Jackson returnerte List<LinkedHashMap> ville denne kaste.
+            list.body.first().status shouldBe "ok"
+
+            val set = klient.get<Set<TestResponseDto>>(URI.create("${wiremock.baseUrl()}/set")).getOrFail()
+            set.body shouldBe setOf(
+                TestResponseDto(status = "ok", antall = 1),
+                TestResponseDto(status = "feil", antall = 2),
+            )
+
+            val map = klient.get<Map<String, TestResponseDto>>(URI.create("${wiremock.baseUrl()}/map")).getOrFail()
+            map.body shouldBe mapOf(
+                "a" to TestResponseDto(status = "ok", antall = 1),
+                "b" to TestResponseDto(status = "feil", antall = 2),
+            )
+            map.body.getValue("a").antall shouldBe 1
+        }
+    }
+
+    @Test
+    fun `stor respons-body leses komplett`() = runTest {
+        withWireMock { wiremock ->
+            val storBody = "x".repeat(1_000_000)
+            wiremock.stubFor(get(urlEqualTo("/stor")).willReturn(aResponse().withStatus(200).withBody(storBody)))
+            val klient = testHttpKlient(timeout = 5.seconds)
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/stor")).getOrFail()
+
+            response.body.length shouldBe 1_000_000
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientHeadersTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientHeadersTest.kt
@@ -1,0 +1,323 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+internal class HttpKlientHeadersTest {
+    @Test
+    fun `header overskriver tidligere verdier for samme key`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/replace"))
+                    .withHeader("X-Foo", equalTo("siste"))
+                    .willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/replace")) {
+                header("X-Foo", "forste")
+                header("X-Foo", "siste")
+            }.getOrFail()
+
+            response.body shouldBe "ok"
+            response.metadata.requestHeaders["X-Foo"] shouldBe listOf("siste")
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/replace")).withHeader("X-Foo", equalTo("siste")),
+            )
+        }
+    }
+
+    @Test
+    fun `addHeader sender flere verdier for samme key som separate header-linjer til serveren`() = runTest {
+        // Bruker custom header (X-Variant) for å unngå at Jetty automatisk gzipper response-bodyen (slik den gjør ved Accept-Encoding: gzip), som ville forstyrret body-assertions.
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/multi")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/multi")) {
+                addHeader("X-Variant", "alpha")
+                addHeader("X-Variant", "beta")
+                addHeader("X-Variant", "gamma")
+            }.getOrFail()
+
+            response.body shouldBe "ok"
+            response.metadata.requestHeaders["X-Variant"] shouldBe listOf("alpha", "beta", "gamma")
+            // Verifiser at alle tre verdiene faktisk ble sendt som separate header-linjer på wire.
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/multi"))
+                    .withHeader("X-Variant", equalTo("alpha"))
+                    .withHeader("X-Variant", equalTo("beta"))
+                    .withHeader("X-Variant", equalTo("gamma")),
+            )
+        }
+    }
+
+    @Test
+    fun `addHeader kombinerer med tidligere header-kall på samme key`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/blandet")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/blandet")) {
+                header("X-Multi", "forste")
+                addHeader("X-Multi", "andre")
+            }.getOrFail()
+
+            response.metadata.requestHeaders["X-Multi"] shouldBe listOf("forste", "andre")
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/blandet"))
+                    .withHeader("X-Multi", equalTo("forste"))
+                    .withHeader("X-Multi", equalTo("andre")),
+            )
+        }
+    }
+
+    @Test
+    fun `header etter addHeader fjerner alle tidligere verdier`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/reset")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/reset")) {
+                addHeader("X-Foo", "a")
+                addHeader("X-Foo", "b")
+                header("X-Foo", "kun-denne")
+            }.getOrFail()
+
+            response.metadata.requestHeaders["X-Foo"] shouldBe listOf("kun-denne")
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/reset")).withHeader("X-Foo", equalTo("kun-denne")),
+            )
+        }
+    }
+
+    @Test
+    fun `header slår opp eksisterende key case-insensitivt og overskriver i stedet for å lage duplikat`() = runTest {
+        // HTTP-headernavn er case-insensitive (RFC 9110 §5.1), så header("X-Foo") etterfulgt av header("x-foo") skal overskrive samme header – ikke sende to separate header-linjer til serveren.
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/case-replace")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val metadata = klient.get<String>(URI.create("${wiremock.baseUrl()}/case-replace")) {
+                header("X-Foo", "forste")
+                header("x-foo", "siste")
+            }.getOrFail().metadata
+
+            // Kun én header beholdes på tvers av casing, med den sist satte verdien.
+            metadata.requestHeaders.keys.count { it.equals("X-Foo", ignoreCase = true) } shouldBe 1
+            metadata.requestHeaderValues("X-Foo") shouldBe listOf("siste")
+            // På wire skal serveren se nøyaktig én verdi for headeren, og den gamle verdien skal være borte.
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/case-replace"))
+                    .withHeader("X-Foo", equalTo("siste")),
+            )
+            wiremock.verify(
+                0,
+                getRequestedFor(urlEqualTo("/case-replace"))
+                    .withHeader("X-Foo", equalTo("forste")),
+            )
+        }
+    }
+
+    @Test
+    fun `addHeader slår opp eksisterende key case-insensitivt og appender på samme header`() = runTest {
+        // addHeader("X-Variant") etterfulgt av addHeader("x-variant") skal legge verdien på samme header, ikke opprette en duplikat-header med annen casing.
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/case-append")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val metadata = klient.get<String>(URI.create("${wiremock.baseUrl()}/case-append")) {
+                addHeader("X-Variant", "alpha")
+                addHeader("x-variant", "beta")
+            }.getOrFail().metadata
+
+            metadata.requestHeaders.keys.count { it.equals("X-Variant", ignoreCase = true) } shouldBe 1
+            metadata.requestHeaderValues("X-Variant") shouldBe listOf("alpha", "beta")
+            wiremock.verify(
+                1,
+                getRequestedFor(urlEqualTo("/case-append"))
+                    .withHeader("X-Variant", equalTo("alpha"))
+                    .withHeader("X-Variant", equalTo("beta")),
+            )
+        }
+    }
+
+    @Test
+    fun `headere bevarer innsettingsrekkefølge i rawRequestString, default-headere havner til slutt`() = runTest {
+        // HttpKlientRequest-kontrakten lover at headere bevarer rekkefølgen konsumenten satte dem i, med klientens default-headere (her Content-Type for JSON-body) lagt til på slutten.
+        // En alfabetisk sortert map ville feilaktig plassert Content-Type ("C") før X-Test ("X").
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                post(urlEqualTo("/rekkefolge")).willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            val metadata = klient.post<String>(URI.create("${wiremock.baseUrl()}/rekkefolge"), """{"a":1}""") {
+                header("X-Test", "1")
+            }.getOrFail().metadata
+
+            val raw = metadata.rawRequestString
+            raw.indexOf("X-Test:") shouldBeLessThan raw.indexOf("Content-Type:")
+        }
+    }
+
+    @Test
+    fun `header etterfulgt av header med annen casing bruker den siste casingen`() = runTest {
+        // Den siste skriveren bestemmer casingen: header("min-header") så header("Min-header") skal ende opp med nøkkelen "Min-header".
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/casing-hh")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val headers = klient.get<String>(URI.create("${wiremock.baseUrl()}/casing-hh")) {
+                header("min-header", "forste")
+                header("Min-header", "siste")
+            }.getOrFail().metadata.requestHeaders
+
+            headers.keys shouldContain "Min-header"
+            headers.keys shouldNotContain "min-header"
+            headers["Min-header"] shouldBe listOf("siste")
+        }
+    }
+
+    @Test
+    fun `header etterfulgt av addHeader med annen casing bruker den siste casingen og beholder begge verdier`() = runTest {
+        // header("min-header") så addHeader("Min-header") skal appende på samme header, med nøkkelen oppdatert til den siste casingen "Min-header".
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/casing-ha")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val headers = klient.get<String>(URI.create("${wiremock.baseUrl()}/casing-ha")) {
+                header("min-header", "forste")
+                addHeader("Min-header", "siste")
+            }.getOrFail().metadata.requestHeaders
+
+            headers.keys shouldContain "Min-header"
+            headers.keys shouldNotContain "min-header"
+            headers["Min-header"] shouldBe listOf("forste", "siste")
+        }
+    }
+
+    @Test
+    fun `addHeader etterfulgt av header med annen casing bruker den siste casingen og overskriver verdiene`() = runTest {
+        // addHeader("min-header") så header("Min-header") skal overskrive verdien og bruke den siste casingen "Min-header".
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/casing-ah")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val headers = klient.get<String>(URI.create("${wiremock.baseUrl()}/casing-ah")) {
+                addHeader("min-header", "forste")
+                header("Min-header", "siste")
+            }.getOrFail().metadata.requestHeaders
+
+            headers.keys shouldContain "Min-header"
+            headers.keys shouldNotContain "min-header"
+            headers["Min-header"] shouldBe listOf("siste")
+        }
+    }
+
+    @Test
+    fun `addHeader etterfulgt av addHeader med annen casing bruker den siste casingen og beholder begge verdier`() = runTest {
+        // addHeader("min-header") så addHeader("Min-header") skal appende på samme header, med nøkkelen oppdatert til den siste casingen "Min-header".
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/casing-aa")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val headers = klient.get<String>(URI.create("${wiremock.baseUrl()}/casing-aa")) {
+                addHeader("min-header", "forste")
+                addHeader("Min-header", "siste")
+            }.getOrFail().metadata.requestHeaders
+
+            headers.keys shouldContain "Min-header"
+            headers.keys shouldNotContain "min-header"
+            headers["Min-header"] shouldBe listOf("forste", "siste")
+        }
+    }
+
+    @Test
+    fun `responseHeader-aksessorene slår opp case-insensitivt`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/svar-headere")).willReturn(
+                    aResponse().withStatus(200).withBody("ok")
+                        .withHeader("X-Enkelt", "verdi")
+                        .withHeader("X-Multi", "a", "b"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val metadata = klient.get<String>(URI.create("${wiremock.baseUrl()}/svar-headere")).getOrFail().metadata
+
+            metadata.responseHeader("x-enkelt") shouldBe "verdi"
+            metadata.responseHeader("X-ENKELT") shouldBe "verdi"
+            metadata.responseHeaderValues("x-multi") shouldBe listOf("a", "b")
+            metadata.responseHeader("finnes-ikke") shouldBe null
+            metadata.responseHeaderValues("finnes-ikke").shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `requestHeader-aksessorene slår opp case-insensitivt`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/req-headere")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val metadata = klient.get<String>(URI.create("${wiremock.baseUrl()}/req-headere")) {
+                header("X-Trace-Id", "trace-1")
+            }.getOrFail().metadata
+
+            metadata.requestHeader("x-trace-id") shouldBe "trace-1"
+        }
+    }
+
+    @Test
+    fun `sensitive headere maskeres i rawRequestString men ikke i den strukturerte header-mappen`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/redaksjon")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val metadata = klient.get<String>(URI.create("${wiremock.baseUrl()}/redaksjon")) {
+                header("authorization", "Bearer hemmelig-token")
+                header("Cookie", "session=hemmelig-cookie")
+            }.getOrFail().metadata
+
+            // rawRequestString er beregnet for logging og maskerer derfor sensitive verdier.
+            metadata.rawRequestString shouldContain "authorization: ***"
+            metadata.rawRequestString shouldContain "Cookie: ***"
+            metadata.rawRequestString shouldNotContain "hemmelig-token"
+            metadata.rawRequestString shouldNotContain "hemmelig-cookie"
+            // Den strukturerte mappen beholder ekte verdier slik at kallere kan inspisere dem programmatisk.
+            metadata.requestHeaders["authorization"] shouldBe listOf("Bearer hemmelig-token")
+            metadata.requestHeaders["Cookie"] shouldBe listOf("session=hemmelig-cookie")
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientLoggingTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientLoggingTest.kt
@@ -1,0 +1,140 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+internal class HttpKlientLoggingTest {
+    @Test
+    fun `kan konfigurere logging globalt og per request`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/logg-info")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            wiremock.stubFor(get(urlEqualTo("/logg-warn")).willReturn(aResponse().withStatus(404).withBody("borte")))
+            wiremock.stubFor(get(urlEqualTo("/logg-error")).willReturn(aResponse().withStatus(500).withBody("feil")))
+            val klient = testHttpKlient(
+                loggingConfig = HttpKlientLoggingConfig(
+                    logger = testLogger(),
+                    loggTilSikkerlogg = true,
+                    inkluderHeadere = true,
+                ),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/logg-info")).getOrFail().body shouldBe "ok"
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/logg-warn")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/logg-error")) {
+                disableLogging()
+            }.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/logg-error")).swap().getOrNull()!!
+                .shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+        }
+    }
+
+    @Test
+    fun `kan konfigurere logging med builder per request`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/per-request-logg")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val logger = testLogger()
+            val klient = testHttpKlient()
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/per-request-logg")) {
+                logging {
+                    this.logger = logger
+                    loggTilSikkerlogg = true
+                    inkluderHeadere = true
+                }
+            }.getOrFail().body shouldBe "ok"
+        }
+    }
+
+    @Test
+    fun `logger NetworkError til sikkerlogg når konfigurert`() = runTest {
+        val uri = stoppedServerUri("/stoppet-med-logg")
+        val klient = testHttpKlient(
+            loggingConfig = HttpKlientLoggingConfig(
+                logger = testLogger(),
+                loggTilSikkerlogg = true,
+            ),
+        )
+
+        klient.get<String>(uri).swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.NetworkError>()
+    }
+
+    @Test
+    fun `logger på riktig nivå per status`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/ok")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            wiremock.stubFor(get(urlEqualTo("/klientfeil")).willReturn(aResponse().withStatus(404)))
+            wiremock.stubFor(get(urlEqualTo("/serverfeil")).willReturn(aResponse().withStatus(500)))
+            val logger = testLogger()
+            val klient = testHttpKlient(loggingConfig = HttpKlientLoggingConfig(logger = logger))
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/ok"))
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/klientfeil"))
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/serverfeil"))
+
+            verify(exactly = 1) { logger.info(any<() -> Any?>()) }
+            verify(exactly = 1) { logger.warn(any<() -> Any?>()) }
+            verify(exactly = 1) { logger.error(any<() -> Any?>()) }
+        }
+    }
+
+    @Test
+    fun `pre-flight-feil logges når logging er aktivert`() = runTest {
+        // En self-refererende DTO feiler JSON-serialisering i toJavaHttpRequest (pre-flight), før noe HTTP-forsøk.
+        // Slike feil skal logges på lik linje med auth-/respons-feil, ikke bli stille i drift.
+        val logger = testLogger()
+        val klient = testHttpKlient(loggingConfig = HttpKlientLoggingConfig(logger = logger))
+
+        klient.post<String>(URI.create("http://localhost/pre-flight"), SelvRefererendeDto())
+            .swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.SerializationError>()
+
+        verify(exactly = 1) { logger.error(any<() -> Any?>()) }
+    }
+
+    @Test
+    fun `disableLogging gir ingen logger-kall`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/stille")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val logger = testLogger()
+            val klient = testHttpKlient(loggingConfig = HttpKlientLoggingConfig(logger = logger))
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/stille")) { disableLogging() }.getOrFail()
+
+            verify(exactly = 0) { logger.info(any<() -> Any?>()) }
+        }
+    }
+
+    @Test
+    fun `sensitive headere maskeres i logg-meldingen`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/logg-redaksjon")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val logger = testLogger()
+            val klient = testHttpKlient(
+                loggingConfig = HttpKlientLoggingConfig(logger = logger, inkluderHeadere = true),
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/logg-redaksjon")) {
+                bearerToken(testAccessToken("logg-hemmelig"))
+            }.getOrFail()
+
+            val messages = mutableListOf<() -> Any?>()
+            verify { logger.info(capture(messages)) }
+            val rendered = messages.joinToString("\n") { it().toString() }
+            rendered.shouldNotContain("logg-hemmelig")
+            rendered.shouldContain("***")
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientPostTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientPostTest.kt
@@ -1,0 +1,313 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+internal class HttpKlientPostTest {
+    @Test
+    fun `request builder sender og mottar json som string`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                post(urlEqualTo("/echo")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"lagret":true}"""),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.request<String>(URI.create("${wiremock.baseUrl()}/echo"), HttpMethod.POST) {
+                header("X-Test", "1")
+                json("""{"navn":"test"}""")
+            }.getOrFail()
+
+            response.body shouldBe """{"lagret":true}"""
+            response.metadata.rawRequestString shouldBe """POST ${wiremock.baseUrl()}/echo
+                |X-Test: 1
+                |Content-Type: application/json
+                |
+                |{"navn":"test"}
+            """.trimMargin()
+            response.metadata.rawResponseString shouldBe """{"lagret":true}"""
+            wiremock.verify(
+                1,
+                postRequestedFor(urlEqualTo("/echo"))
+                    .withoutHeader("Accept")
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withHeader("X-Test", equalTo("1"))
+                    .withRequestBody(equalToJson("""{"navn":"test"}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `post serialiserer request-dto og returnerer json som string`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                post(urlEqualTo("/dto-til-string")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"mottatt":true}"""),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.post<String>(URI.create("${wiremock.baseUrl()}/dto-til-string")) {
+                json(TestRequestDto(id = "abc", antall = 2))
+            }.getOrFail()
+
+            response.body shouldBe """{"mottatt":true}"""
+            wiremock.verify(
+                1,
+                postRequestedFor(urlEqualTo("/dto-til-string"))
+                    .withoutHeader("Accept")
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"id":"abc","antall":2}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `post serialiserer request-dto og deserialiserer response-dto`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                post(urlEqualTo("/dto-til-dto")).willReturn(
+                    aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("X-Response", "ja")
+                        .withBody("""{"status":"opprettet","antall":4}"""),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val response = klient.post<TestResponseDto>(URI.create("${wiremock.baseUrl()}/dto-til-dto")) {
+                json(TestRequestDto(id = "abc", antall = 4))
+            }.getOrFail()
+
+            response.statusCode shouldBe 201
+            response.body shouldBe TestResponseDto(status = "opprettet", antall = 4)
+            response.metadata.responseHeaders["X-Response"] shouldBe listOf("ja")
+            response.metadata.requestHeaders["Accept"] shouldBe listOf("application/json")
+            response.metadata.requestHeaders["Content-Type"] shouldBe listOf("application/json")
+            wiremock.verify(
+                1,
+                postRequestedFor(urlEqualTo("/dto-til-dto"))
+                    .withHeader("Accept", equalTo("application/json"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"id":"abc","antall":4}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `body sender raw tekst med eksplisitte headere`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                post(urlEqualTo("/raw")).withHeader("Content-Type", equalTo("text/plain")).willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody("ok"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/raw")) {
+                acceptJson()
+                contentTypeJson()
+                header("Content-Type", "text/plain")
+                body("hei")
+            }.getOrFail().body shouldBe "ok"
+        }
+    }
+
+    @Test
+    fun `body-shorthand for post put patch sender DTO som JSON`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/p")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            wiremock.stubFor(
+                com.github.tomakehurst.wiremock.client.WireMock.put(urlEqualTo("/u"))
+                    .willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            wiremock.stubFor(
+                com.github.tomakehurst.wiremock.client.WireMock.patch(urlEqualTo("/a"))
+                    .willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+            val dto = TestRequestDto(id = "abc", antall = 1)
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/p"), dto).getOrFail().body shouldBe "ok"
+            klient.put<String>(URI.create("${wiremock.baseUrl()}/u"), dto).getOrFail().body shouldBe "ok"
+            klient.patch<String>(URI.create("${wiremock.baseUrl()}/a"), dto).getOrFail().body shouldBe "ok"
+
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/p"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"id":"abc","antall":1}""")),
+            )
+            wiremock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor(urlEqualTo("/u"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"id":"abc","antall":1}""")),
+            )
+            wiremock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor(urlEqualTo("/a"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"id":"abc","antall":1}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `body-shorthand med extra builder kan overstyre headere`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/x")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/x"), TestRequestDto(id = "id", antall = 2)) {
+                header("X-Trace-Id", "trace-1")
+            }.getOrFail()
+
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/x"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withHeader("X-Trace-Id", equalTo("trace-1"))
+                    .withRequestBody(equalToJson("""{"id":"id","antall":2}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `body-shorthand med JSON-string sender verbatim uten dobbel-serialisering`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/verbatim")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/verbatim"), """{"navn":"verbatim"}""").getOrFail()
+
+            // Hadde strengen blitt serialisert på nytt ville bodyen vært en JSON-string-literal ("{\"navn\":...}"), som ikke matcher dette JSON-objektet.
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/verbatim"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"navn":"verbatim"}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `formUrlEncoded url-koder felter og setter content-type`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/token")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/token")) {
+                formUrlEncoded("grant_type" to "client_credentials", "scope" to "api://app x")
+            }.getOrFail().body shouldBe "ok"
+
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/token"))
+                    .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+                    .withRequestBody(equalTo("grant_type=client_credentials&scope=api%3A%2F%2Fapp+x")),
+            )
+        }
+    }
+
+    @Test
+    fun `formUrlEncoded med varargs bevarer gjentatte nøkler`() = runTest {
+        // For application/x-www-form-urlencoded er gjentatte felter gyldige (f.eks. scope=a&scope=b), så varargs-formen må ikke kollapse duplikater via toMap().
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/scopes")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/scopes")) {
+                formUrlEncoded("scope" to "a", "scope" to "b", "grant_type" to "client_credentials")
+            }.getOrFail().body shouldBe "ok"
+
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/scopes"))
+                    .withRequestBody(equalTo("scope=a&scope=b&grant_type=client_credentials")),
+            )
+        }
+    }
+
+    @Test
+    fun `body-shorthand med JSON-string for put og patch sender verbatim`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                com.github.tomakehurst.wiremock.client.WireMock.put(urlEqualTo("/vu"))
+                    .willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            wiremock.stubFor(
+                com.github.tomakehurst.wiremock.client.WireMock.patch(urlEqualTo("/va"))
+                    .willReturn(aResponse().withStatus(200).withBody("ok")),
+            )
+            val klient = testHttpKlient()
+
+            klient.put<String>(URI.create("${wiremock.baseUrl()}/vu"), """{"navn":"u"}""").getOrFail()
+            klient.patch<String>(URI.create("${wiremock.baseUrl()}/va"), """{"navn":"a"}""").getOrFail()
+
+            wiremock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor(urlEqualTo("/vu"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"navn":"u"}""")),
+            )
+            wiremock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor(urlEqualTo("/va"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withRequestBody(equalToJson("""{"navn":"a"}""")),
+            )
+        }
+    }
+
+    @Test
+    fun `formUrlEncoded med Map honorerer eksisterende content-type`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/form-map")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            klient.post<String>(URI.create("${wiremock.baseUrl()}/form-map")) {
+                header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                formUrlEncoded(mapOf("a" to "1", "b" to "to ord"))
+            }.getOrFail().body shouldBe "ok"
+
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/form-map"))
+                    .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded; charset=UTF-8"))
+                    .withRequestBody(equalTo("a=1&b=to+ord")),
+            )
+        }
+    }
+
+    @Test
+    fun `formUrlEncoded honorerer eksisterende content-type med annen casing og lager ikke duplikat`() = runTest {
+        // HTTP-headernavn er case-insensitive (RFC 9110 §5.1), så en allerede satt "content-type" skal forhindre at formUrlEncoded legger til en duplikat "Content-Type".
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/form-casing")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            val klient = testHttpKlient()
+
+            val metadata = klient.post<String>(URI.create("${wiremock.baseUrl()}/form-casing")) {
+                header("content-type", "application/x-www-form-urlencoded; charset=UTF-8")
+                formUrlEncoded(mapOf("a" to "1"))
+            }.getOrFail().metadata
+
+            // Kun én content-type-header på tvers av casing, med konsumentens verdi beholdt.
+            metadata.requestHeaders.keys.count { it.equals("Content-Type", ignoreCase = true) } shouldBe 1
+            metadata.requestHeaderValues("content-type") shouldBe listOf("application/x-www-form-urlencoded; charset=UTF-8")
+            wiremock.verify(
+                postRequestedFor(urlEqualTo("/form-casing"))
+                    .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded; charset=UTF-8")),
+            )
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientRedirectTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientRedirectTest.kt
@@ -1,0 +1,53 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpClient
+
+internal class HttpKlientRedirectTest {
+    @Test
+    fun `default følger ikke redirects og eksponerer 3xx som UventetStatus`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/fra")).willReturn(
+                    aResponse().withStatus(302).withHeader("Location", "${wiremock.baseUrl()}/til"),
+                ),
+            )
+            wiremock.stubFor(get(urlEqualTo("/til")).willReturn(aResponse().withStatus(200).withBody("fulgt")))
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/fra")).swap().getOrNull()!!
+
+            val uventet = error.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            uventet.statusCode shouldBe 302
+        }
+    }
+
+    @Test
+    fun `followRedirects NORMAL følger redirecten`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/fra")).willReturn(
+                    aResponse().withStatus(302).withHeader("Location", "${wiremock.baseUrl()}/til"),
+                ),
+            )
+            wiremock.stubFor(get(urlEqualTo("/til")).willReturn(aResponse().withStatus(200).withBody("fulgt")))
+            val klient = HttpKlient(clock = fixedClock) {
+                followRedirects = HttpClient.Redirect.NORMAL
+            }
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/fra")).getOrFail()
+
+            response.statusCode shouldBe 200
+            response.body shouldBe "fulgt"
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientResponseTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientResponseTest.kt
@@ -1,0 +1,177 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import kotlin.concurrent.thread
+
+internal class HttpKlientResponseTest {
+    @Test
+    fun `HttpKlientResponse avviser statuskoder utenfor tresifret http-range`() {
+        listOf(-1, 99, 1000).forEach { statusCode ->
+            shouldThrowWithMessage<IllegalArgumentException>("statusCode må være en tresifret HTTP-statuskode") {
+                HttpKlientResponse(statusCode = statusCode, body = "body", metadata = tomMetadata())
+            }
+        }
+    }
+
+    @Test
+    fun `HttpKlientResponse godtar tresifrede statuskoder`() {
+        HttpKlientResponse(statusCode = 100, body = "body", metadata = tomMetadata()).statusCode shouldBe 100
+        HttpKlientResponse(statusCode = 599, body = "body", metadata = tomMetadata()).statusCode shouldBe 599
+        HttpKlientResponse(statusCode = 600, body = "body", metadata = tomMetadata()).statusCode shouldBe 600
+    }
+
+    @Test
+    fun `Java HttpClient returnerer tresifrede statuser som HttpKlientResponse aksepterer`() {
+        listOf("200", "599", "600", "999").forEach { statusToken ->
+            val response = javaHttpResponseForRawStatusToken(statusToken)
+            val statusCode = statusToken.toInt()
+
+            response.statusCode() shouldBe statusCode
+            HttpKlientResponse(
+                statusCode = response.statusCode(),
+                body = response.body(),
+                metadata = tomMetadata(responseHeaders = response.headers().map()),
+            ).statusCode shouldBe statusCode
+        }
+    }
+
+    @Test
+    fun `Java HttpClient returnerer de tre første sifrene for positive overflow-statuser`() {
+        mapOf(
+            "2147483648" to 214,
+            "9223372036854775808" to 922,
+        ).forEach { (statusToken, expectedStatusCode) ->
+            val response = javaHttpResponseForRawStatusToken(statusToken)
+
+            response.statusCode() shouldBe expectedStatusCode
+            HttpKlientResponse(
+                statusCode = response.statusCode(),
+                body = response.body(),
+                metadata = tomMetadata(responseHeaders = response.headers().map()),
+            ).statusCode shouldBe expectedStatusCode
+        }
+    }
+
+    @Test
+    fun `Java HttpClient avviser ugyldige raw statuslinjer`() {
+        listOf(
+            "99",
+            "1000",
+            "-2147483649",
+            "-9223372036854775809",
+        ).forEach { statusToken ->
+            shouldThrow<Exception> {
+                javaHttpResponseForRawStatusToken(statusToken)
+            }
+        }
+    }
+
+    @Test
+    fun `Java HttpClient returnerer status 600 fra WireMock`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/status-600")).willReturn(
+                    aResponse()
+                        .withStatus(600)
+                        .withBody("utenfor-standard-range"),
+                ),
+            )
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create("${wiremock.baseUrl()}/status-600"))
+                .GET()
+                .build()
+
+            val response = HttpClient.newHttpClient()
+                .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .get()
+
+            response.statusCode() shouldBe 600
+            response.body() shouldBe "utenfor-standard-range"
+        }
+    }
+
+    @Test
+    fun `HttpKlient returnerer UventetStatus for WireMock status 600 med default successStatus`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/status-600")).willReturn(
+                    aResponse()
+                        .withStatus(600)
+                        .withBody("utenfor-standard-range"),
+                ),
+            )
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/status-600")).swap().getOrNull()!!
+            val ikke2xx = error as HttpKlientError.UventetStatus
+
+            ikke2xx.statusCode shouldBe 600
+            ikke2xx.body shouldBe "utenfor-standard-range"
+            ikke2xx.metadata.rawRequestString shouldBe "GET ${wiremock.baseUrl()}/status-600"
+            ikke2xx.metadata.rawResponseString shouldBe "utenfor-standard-range"
+            ikke2xx.metadata.statusCode shouldBe 600
+        }
+    }
+
+    @Test
+    fun `HttpKlient kan returnere status 600 hvis konsumenten eksplisitt definerer den som success`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/status-600")).willReturn(
+                    aResponse()
+                        .withStatus(600)
+                        .withBody("utenfor-standard-range"),
+                ),
+            )
+            val klient = testHttpKlient(successStatus = { it == 600 })
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/status-600")).getOrFail().statusCode shouldBe 600
+        }
+    }
+}
+
+private fun javaHttpResponseForRawStatusToken(statusToken: String): HttpResponse<String> {
+    ServerSocket(0).use { serverSocket ->
+        val serverThread = thread(start = true) {
+            serverSocket.accept().use { socket ->
+                val reader = socket.getInputStream().bufferedReader(StandardCharsets.US_ASCII)
+                while (reader.readLine()?.isNotEmpty() == true) {
+                    // Leser hele requesten før vi skriver raw response.
+                }
+                socket.getOutputStream().writer(StandardCharsets.US_ASCII).use { writer ->
+                    writer.write("HTTP/1.1 $statusToken Test\r\n")
+                    writer.write("Content-Length: 2\r\n")
+                    writer.write("Connection: close\r\n")
+                    writer.write("\r\n")
+                    writer.write("OK")
+                    writer.flush()
+                }
+            }
+        }
+        return try {
+            HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:${serverSocket.localPort}/raw-status"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+        } finally {
+            serverThread.join(1000)
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientRetryTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientRetryTest.kt
@@ -1,0 +1,546 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.resilience.Schedule
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.libs.common.TikkendeKlokke
+import no.nav.tiltakspenger.libs.common.getOrFail
+import no.nav.tiltakspenger.libs.httpklient.retry.AttemptOutcome
+import no.nav.tiltakspenger.libs.httpklient.retry.NeverRetry
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryDecisionContext
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryOnServerErrorsAndNetwork
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryOutcome
+import no.nav.tiltakspenger.libs.httpklient.retry.defaultLogExcessiveRetries
+import no.nav.tiltakspenger.libs.httpklient.retry.isIdempotent
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Liten hjelper for tester som bare trenger en schedule som tillater N retries uten ventetid.
+ */
+private fun recursSchedule(maxRetries: Int): Schedule<AttemptOutcome, *> =
+    Schedule.recurs(maxRetries.toLong())
+
+internal class HttpKlientRetryTest {
+
+    @Test
+    fun `default RetryConfig retry-er ikke`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/x")).willReturn(aResponse().withStatus(503).withBody("nei")))
+            val klient = testHttpKlient()
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/x")).swap().getOrNull()!!
+
+            val ikke2xx = error.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            ikke2xx.metadata.attempts shouldBe 1
+            ikke2xx.metadata.attemptDurations shouldHaveSize 1
+        }
+    }
+
+    @Test
+    fun `RetryConfig uten eksplisitt retryOn retry-er ikke som default`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/default-retryon")).willReturn(aResponse().withStatus(503)))
+            // Default retryOn er NeverRetry: en bar RetryConfig(schedule = ...) retry-er ikke før konsumenten eksplisitt opt-iner.
+            // GET er idempotent og 503 er en retry-bar status, så det er kun default-predikatet (NeverRetry) som hindrer retry her.
+            val klient = testHttpKlient(retryConfig = RetryConfig(schedule = recursSchedule(2)))
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/default-retryon")).swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 1
+        }
+    }
+
+    @Test
+    fun `respons godtatt av successStatus retry-es ikke selv om statusen er i retryable-mengden`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/503-er-ok")).willReturn(aResponse().withStatus(503).withBody("degradert")))
+            // Konsumenten godtar 503 som suksess; da skal retry-loopen ikke brenne budsjett på den.
+            val klient = testHttpKlient(
+                successStatus = { it == 503 || it in 200..299 },
+                retryConfig = RetryConfig(schedule = recursSchedule(3), retryOn = { true }),
+            )
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/503-er-ok")).getOrFail()
+
+            response.statusCode shouldBe 503
+            response.body shouldBe "degradert"
+            response.metadata.attempts shouldBe 1
+            wiremock.verify(1, getRequestedFor(urlEqualTo("/503-er-ok")))
+        }
+    }
+
+    @Test
+    fun `alle retryable statuskoder retry-es, naboer gjør det ikke`() = runTest {
+        suspend fun attemptsForStatus(status: Int): Int = withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/status")).willReturn(aResponse().withStatus(status)))
+            val klient = testHttpKlient(retryConfig = RetryConfig(schedule = recursSchedule(1), retryOn = { true }))
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/status")).swap().getOrNull()!!.metadata.attempts
+        }
+
+        listOf(408, 425, 429, 500, 502, 503, 504).forEach { status ->
+            withClue("status $status skal være retryable") { attemptsForStatus(status) shouldBe 2 }
+        }
+        listOf(400, 404, 501, 505).forEach { status ->
+            withClue("status $status skal ikke være retryable") { attemptsForStatus(status) shouldBe 1 }
+        }
+    }
+
+    @Test
+    fun `retry lykkes på andre forsøk`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(
+                get(urlEqualTo("/y"))
+                    .inScenario("retry-y").whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(aResponse().withStatus(503))
+                    .willSetStateTo("ok"),
+            )
+            wiremock.stubFor(
+                get(urlEqualTo("/y"))
+                    .inScenario("retry-y").whenScenarioStateIs("ok")
+                    .willReturn(aResponse().withStatus(200).withBody("hei")),
+            )
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(
+                    schedule = recursSchedule(2),
+                    retryOn = RetryOnServerErrorsAndNetwork,
+                ),
+            )
+
+            val response = klient.get<String>(URI.create("${wiremock.baseUrl()}/y")).getOrFail()
+
+            response.statusCode shouldBe 200
+            response.body shouldBe "hei"
+            response.metadata.attempts shouldBe 2
+            response.metadata.attemptDurations shouldHaveSize 2
+        }
+    }
+
+    @Test
+    fun `bruker opp alle retries og returnerer siste feil`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/z")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(2), retryOn = RetryOnServerErrorsAndNetwork),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/z")).swap().getOrNull()!!
+
+            val ikke2xx = error.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            ikke2xx.metadata.attempts shouldBe 3
+            ikke2xx.metadata.attemptDurations shouldHaveSize 3
+        }
+    }
+
+    @Test
+    fun `4xx blir ikke retry-et med default-predikat for idempotente metoder`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/q")).willReturn(aResponse().withStatus(404)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(2), retryOn = RetryOnServerErrorsAndNetwork),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/q")).swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 1
+        }
+    }
+
+    @Test
+    fun `POST blir ikke retry-et med default-predikat`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/p")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(2), retryOn = RetryOnServerErrorsAndNetwork),
+            )
+
+            val error = klient.post<String>(URI.create("${wiremock.baseUrl()}/p")) { body("x") }.swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 1
+        }
+    }
+
+    @Test
+    fun `POST kan retry-es med custom predikat`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(post(urlEqualTo("/p2")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(
+                    schedule = recursSchedule(1),
+                    retryOn = {
+                        val outcome = it.outcome
+                        outcome is AttemptOutcome.Status && outcome.statusCode == 503
+                    },
+                ),
+            )
+
+            val error = klient.post<String>(URI.create("${wiremock.baseUrl()}/p2")) { body("x") }.swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 2
+        }
+    }
+
+    @Test
+    fun `retry på NetworkError`() = runTest {
+        val uri = stoppedServerUri("/dod")
+        var calls = 0
+        val klient = testHttpKlient(
+            retryConfig = RetryConfig(
+                schedule = recursSchedule(2),
+                retryOn = { ctx ->
+                    calls++
+                    ctx.outcome is AttemptOutcome.Failure
+                },
+            ),
+        )
+
+        val error = klient.get<String>(uri).swap().getOrNull()!!
+
+        (error is HttpKlientError.NetworkError || error is HttpKlientError.Timeout) shouldBe true
+        error.metadata.attempts shouldBe 3
+        calls shouldBe 3
+    }
+
+    @Test
+    fun `per-request retryConfig overstyrer klient-default`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/o")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(retryConfig = RetryConfig.None)
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/o")) {
+                retryConfig = RetryConfig(schedule = recursSchedule(1), retryOn = RetryOnServerErrorsAndNetwork)
+            }.swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 2
+        }
+    }
+
+    @Test
+    fun `excessiveRetries-callback firer når terskelen er passert`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/e")).willReturn(aResponse().withStatus(503)))
+            var notified: RetryOutcome? = null
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(2))
+                    .withRetryOn(RetryOnServerErrorsAndNetwork)
+                    .notifyOnExcessiveRetries(threshold = 2) { notified = it },
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/e"))
+
+            val outcome = notified!!
+            outcome.attempts shouldBe 3
+            outcome.finalStatusCode shouldBe 503
+            outcome.finalError.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+            outcome.attemptDurations shouldHaveSize 3
+        }
+    }
+
+    @Test
+    fun `excessiveRetries-callback firer ikke under terskelen`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/u")).willReturn(aResponse().withStatus(200).withBody("ok")))
+            var notified = false
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(2))
+                    .withRetryOn(RetryOnServerErrorsAndNetwork)
+                    .notifyOnExcessiveRetries(threshold = 1) { notified = true },
+            )
+
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/u")).getOrFail()
+
+            notified shouldBe false
+        }
+    }
+
+    @Test
+    fun `excessiveRetries-callback firer for NetworkError-utfall`() = runTest {
+        val uri = stoppedServerUri("/n")
+        var notified: RetryOutcome? = null
+        val klient = testHttpKlient(
+            retryConfig = RetryConfig(schedule = recursSchedule(1))
+                .withRetryOn(RetryOnServerErrorsAndNetwork)
+                .notifyOnExcessiveRetries(threshold = 1) { notified = it },
+        )
+
+        klient.get<String>(uri)
+
+        val outcome = notified!!
+        outcome.finalStatusCode shouldBe null
+        outcome.finalError.shouldBeInstanceOf<HttpKlientError.NetworkError>()
+    }
+
+    @Test
+    fun `default onExcessiveRetries logger uten å kaste`() {
+        defaultLogExcessiveRetries(
+            RetryOutcome(
+                attempts = 3,
+                totalDuration = 100.milliseconds,
+                attemptDurations = listOf(40.milliseconds, 30.milliseconds, 30.milliseconds),
+                finalStatusCode = 503,
+                finalError = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `RetryConfig validerer input`() {
+        shouldThrowWithMessage<IllegalArgumentException>("excessiveRetriesThreshold må være minst 1 (terskelen telles i antall retries), var -1") {
+            RetryConfig(schedule = Schedule.recurs(0L), excessiveRetriesThreshold = -1)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("excessiveRetriesThreshold må være minst 1 (terskelen telles i antall retries), var -1") {
+            RetryConfig(schedule = Schedule.recurs(0L)).notifyOnExcessiveRetries(threshold = -1)
+        }
+    }
+
+    @Test
+    fun `RetryConfig fluent helpers oppdaterer kun relevante felter`() {
+        val callback: (RetryOutcome) -> Unit = {}
+        val config = RetryConfig(schedule = recursSchedule(3))
+            .withRetryOn(RetryOnServerErrorsAndNetwork)
+            .notifyOnExcessiveRetries(threshold = 2, onExcessiveRetries = callback)
+
+        config.retryOn shouldBe RetryOnServerErrorsAndNetwork
+        config.excessiveRetriesThreshold shouldBe 2
+        config.onExcessiveRetries shouldBe callback
+
+        val utenVarsling = config.withoutExcessiveRetriesNotification()
+
+        utenVarsling.schedule shouldBe config.schedule
+        utenVarsling.retryOn shouldBe RetryOnServerErrorsAndNetwork
+        utenVarsling.excessiveRetriesThreshold shouldBe null
+        utenVarsling.onExcessiveRetries shouldBe callback
+    }
+
+    @Test
+    fun `RetryConfig exponential factory bygger schedule som retry-er`() = runTest {
+        val cfg = RetryConfig.exponential(
+            maxRetries = 1,
+            initialDelay = 1.milliseconds,
+            maxDelay = 10.milliseconds,
+            jitter = false,
+            random = Random(seed = 1),
+        )
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/exp")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(retryConfig = cfg)
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/exp")).swap().getOrNull()!!
+            error.metadata.attempts shouldBe 2
+        }
+    }
+
+    @Test
+    fun `RetryConfig exponential med jitter bygger schedule`() = runTest {
+        val cfg = RetryConfig.exponential(
+            maxRetries = 1,
+            initialDelay = 1.milliseconds,
+            maxDelay = 5.milliseconds,
+            jitter = true,
+            random = Random(seed = 7),
+        )
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/jit")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(retryConfig = cfg)
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/jit")).swap().getOrNull()!!
+                .metadata.attempts shouldBe 2
+        }
+    }
+
+    @Test
+    fun `RetryConfig exponential validerer input`() {
+        shouldThrowWithMessage<IllegalArgumentException>("maxRetries kan ikke være negativ, var -1") {
+            RetryConfig.exponential(maxRetries = -1)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("initialDelay kan ikke være negativ, var -1ms") {
+            RetryConfig.exponential(maxRetries = 1, initialDelay = (-1).milliseconds)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("maxDelay (50ms) må være >= initialDelay (100ms)") {
+            RetryConfig.exponential(maxRetries = 1, initialDelay = 100.milliseconds, maxDelay = 50.milliseconds)
+        }
+    }
+
+    @Test
+    fun `RetryConfig fixed factory venter mellom forsøk`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/b")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig.fixed(maxRetries = 1, delay = 5.milliseconds),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/b")).swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 2
+        }
+    }
+
+    @Test
+    fun `RetryConfig fixed validerer input`() {
+        shouldThrowWithMessage<IllegalArgumentException>("maxRetries kan ikke være negativ, var -1") {
+            RetryConfig.fixed(maxRetries = -1, delay = ZERO)
+        }
+        shouldThrowWithMessage<IllegalArgumentException>("delay kan ikke være negativ, var -1ms") {
+            RetryConfig.fixed(maxRetries = 1, delay = (-1).milliseconds)
+        }
+    }
+
+    @Test
+    fun `NeverRetry returnerer false for alle utfall`() {
+        NeverRetry(RetryDecisionContext(HttpMethod.GET, 1, AttemptOutcome.Status(500))) shouldBe false
+    }
+
+    @Test
+    fun `RetryOnServerErrorsAndNetwork tillater idempotente metoder og avviser andre`() {
+        val anyOutcome = AttemptOutcome.Status(500)
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.GET, 1, anyOutcome)) shouldBe true
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.HEAD, 1, anyOutcome)) shouldBe true
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.OPTIONS, 1, anyOutcome)) shouldBe true
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.PUT, 1, anyOutcome)) shouldBe true
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.DELETE, 1, anyOutcome)) shouldBe true
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.POST, 1, anyOutcome)) shouldBe false
+        RetryOnServerErrorsAndNetwork(RetryDecisionContext(HttpMethod.PATCH, 1, anyOutcome)) shouldBe false
+    }
+
+    @Test
+    fun `isIdempotent dekker alle metoder`() {
+        HttpMethod.GET.isIdempotent() shouldBe true
+        HttpMethod.HEAD.isIdempotent() shouldBe true
+        HttpMethod.OPTIONS.isIdempotent() shouldBe true
+        HttpMethod.PUT.isIdempotent() shouldBe true
+        HttpMethod.DELETE.isIdempotent() shouldBe true
+        HttpMethod.POST.isIdempotent() shouldBe false
+        HttpMethod.PATCH.isIdempotent() shouldBe false
+    }
+
+    @Test
+    fun `HttpKlientMetadata avviser negative attempts`() {
+        shouldThrowWithMessage<IllegalArgumentException>("attempts kan ikke være negativ, var -1") {
+            tomMetadata().copy(attempts = -1)
+        }
+    }
+
+    @Test
+    fun `retryable-flagg på HttpKlientError`() {
+        val md = tomMetadata()
+        HttpKlientError.Timeout(RuntimeException(), md).retryable shouldBe true
+        HttpKlientError.NetworkError(RuntimeException(), md).retryable shouldBe true
+        HttpKlientError.InvalidRequest(RuntimeException(), md).retryable shouldBe false
+        HttpKlientError.SerializationError(RuntimeException(), md).retryable shouldBe false
+        HttpKlientError.DeserializationError(RuntimeException(), "x", 200, md).retryable shouldBe false
+        HttpKlientError.UventetStatus(408, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(425, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(429, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(500, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(502, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(503, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(504, "", md).retryable shouldBe true
+        HttpKlientError.UventetStatus(501, "", md).retryable shouldBe false
+        HttpKlientError.UventetStatus(599, "", md).retryable shouldBe false
+        HttpKlientError.UventetStatus(400, "", md).retryable shouldBe false
+        HttpKlientError.UventetStatus(404, "", md).retryable shouldBe false
+        HttpKlientError.UventetStatus(304, "", md).retryable shouldBe false
+        HttpKlientError.AuthError(RuntimeException(), md).retryable shouldBe false
+    }
+
+    @Test
+    fun `retryable-flagg på AttemptOutcome`() {
+        AttemptOutcome.Status(200).retryable shouldBe false
+        AttemptOutcome.Status(404).retryable shouldBe false
+        AttemptOutcome.Status(429).retryable shouldBe true
+        AttemptOutcome.Status(500).retryable shouldBe true
+        AttemptOutcome.Status(503).retryable shouldBe true
+        AttemptOutcome.Timeout(RuntimeException()).retryable shouldBe true
+        AttemptOutcome.NetworkError(RuntimeException()).retryable shouldBe true
+    }
+
+    @Test
+    fun `loop retry-er ikke ikke-retryable utfall selv om predikatet sier ja`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/g")).willReturn(aResponse().withStatus(404)))
+            var predicateCalls = 0
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(
+                    schedule = recursSchedule(5),
+                    retryOn = {
+                        predicateCalls++
+                        true
+                    },
+                ),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/g")).swap().getOrNull()!!
+
+            error.metadata.attempts shouldBe 1
+            predicateCalls shouldBe 0
+        }
+    }
+
+    @Test
+    fun `Schedule fra Arrow kan brukes direkte uten faktorymetoder`() = runTest {
+        // Demonstrerer at konsumenter kan bygge sin egen Schedule.
+        val schedule: Schedule<AttemptOutcome, *> =
+            Schedule.spaced<AttemptOutcome>(1.milliseconds)
+                .zipLeft(Schedule.recurs(2L))
+
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/s")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = schedule, retryOn = RetryOnServerErrorsAndNetwork),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/s")).swap().getOrNull()!!
+            error.metadata.attempts shouldBe 3
+        }
+    }
+
+    @Test
+    fun `per-forsøk varigheter måles mot klokka`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/tikk")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig(schedule = recursSchedule(1), retryOn = RetryOnServerErrorsAndNetwork),
+                clock = TikkendeKlokke(),
+            )
+
+            val error = klient.get<String>(URI.create("${wiremock.baseUrl()}/tikk")).swap().getOrNull()!!
+
+            // TikkendeKlokke tikker 1 sekund per instant()-kall, og RetryExecutor leser klokka én gang ved start og slutt av hvert forsøk.
+            // Det gir deterministiske varigheter: hvert forsøk «varer» 1 sekund, og total tid spenner over alle seks instant()-kallene.
+            error.metadata.attemptDurations shouldContainExactly listOf(1.seconds, 1.seconds)
+            error.metadata.totalDuration shouldBe 5.seconds
+        }
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun `fixed backoff venter konfigurert tid mellom forsøk`() = runTest {
+        withWireMock { wiremock ->
+            wiremock.stubFor(get(urlEqualTo("/backoff")).willReturn(aResponse().withStatus(503)))
+            val klient = testHttpKlient(
+                retryConfig = RetryConfig.fixed(maxRetries = 2, delay = 10.milliseconds, retryOn = RetryOnServerErrorsAndNetwork),
+            )
+
+            val før = testScheduler.currentTime
+            klient.get<String>(URI.create("${wiremock.baseUrl()}/backoff")).swap().getOrNull()!!
+            val virtuellTidBrukt = testScheduler.currentTime - før
+
+            // 3 forsøk = 2 retries, hver med 10 ms backoff i virtuell tid (de faktiske HTTP-kallene bruker ikke virtuell tid).
+            virtuellTidBrukt shouldBe 20
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientTest.kt
@@ -1,0 +1,139 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import arrow.core.right
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class HttpKlientTest {
+    @Test
+    fun `reified request extension uten builder delegerer til interface`() = runTest {
+        val klient = RecordingHttpKlient()
+
+        klient.request<String>(URI.create("http://localhost/request"), HttpMethod.GET).rightOrThrow()
+
+        klient.calls.shouldContainExactly(
+            RecordedCall(
+                uri = URI.create("http://localhost/request"),
+                responseType = typeOf<String>(),
+                request = HttpKlientRequest(
+                    uri = URI.create("http://localhost/request"),
+                    method = HttpMethod.GET,
+                    headers = emptyMap(),
+                    body = null,
+                    timeout = null,
+                    authToken = null,
+                    successStatus = null,
+                    loggingConfig = null,
+                    retryConfig = null,
+                    circuitBreakerConfig = null,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `reified request extension med builder delegerer til interface`() = runTest {
+        val klient = RecordingHttpKlient()
+
+        klient.request<String>(URI.create("http://localhost/request-builder"), HttpMethod.POST) {
+            body("raw")
+            timeout = 123.milliseconds
+        }.rightOrThrow()
+
+        klient.calls.single().request.method shouldBe HttpMethod.POST
+        klient.calls.single().request.body shouldBe HttpKlientRequest.Body.Raw("raw")
+        klient.calls.single().request.timeout shouldBe 123.milliseconds
+    }
+
+    @Test
+    fun `verb extensions setter riktig metode`() = runTest {
+        val klient = RecordingHttpKlient()
+        val uri = URI.create("http://localhost/verb")
+
+        klient.get<String>(uri).rightOrThrow()
+        klient.post<String>(uri).rightOrThrow()
+        klient.put<String>(uri).rightOrThrow()
+        klient.patch<String>(uri).rightOrThrow()
+        klient.delete<String>(uri).rightOrThrow()
+        klient.head<String>(uri).rightOrThrow()
+        klient.options<String>(uri).rightOrThrow()
+
+        klient.calls.map { it.request.method } shouldBe listOf(
+            HttpMethod.GET,
+            HttpMethod.POST,
+            HttpMethod.PUT,
+            HttpMethod.PATCH,
+            HttpMethod.DELETE,
+            HttpMethod.HEAD,
+            HttpMethod.OPTIONS,
+        )
+    }
+
+    @Test
+    fun `request materialisering dekker alle body-varianter`() {
+        RequestBuilder(URI.create("http://localhost/raw"))
+            .apply { body("raw") }
+            .materialize(typeOf<String>(), HttpMethod.GET)
+            .body shouldBe HttpKlientRequest.Body.Raw("raw")
+
+        RequestBuilder(URI.create("http://localhost/raw-json"))
+            .apply { json("{}") }
+            .materialize(typeOf<String>(), HttpMethod.GET)
+            .body shouldBe HttpKlientRequest.Body.RawJson("{}")
+
+        val dto = TestRequestDto(id = "id", antall = 1)
+        RequestBuilder(URI.create("http://localhost/json"))
+            .apply { json(dto) }
+            .materialize(typeOf<String>(), HttpMethod.GET)
+            .body shouldBe HttpKlientRequest.Body.Json(dto)
+
+        RequestBuilder(URI.create("http://localhost/no-body"))
+            .materialize(typeOf<String>(), HttpMethod.GET)
+            .body shouldBe null
+    }
+}
+
+private data class RecordedCall(
+    val uri: URI,
+    val responseType: KType,
+    val request: HttpKlientRequest,
+)
+
+private class RecordingHttpKlient : HttpKlient {
+    val calls = mutableListOf<RecordedCall>()
+
+    override suspend fun <Response : Any> request(
+        request: HttpKlientRequest,
+        responseType: KType,
+    ): Either<HttpKlientError, HttpKlientResponse<Response>> {
+        calls += RecordedCall(uri = request.uri, responseType = responseType, request = request)
+        @Suppress("UNCHECKED_CAST")
+        return HttpKlientResponse(
+            statusCode = 200,
+            body = "ok" as Response,
+            metadata = HttpKlientMetadata(
+                rawRequestString = "${request.method} ${request.uri}",
+                rawResponseString = "ok",
+                requestHeaders = request.headers,
+                responseHeaders = emptyMap(),
+                statusCode = 200,
+                attempts = 1,
+                attemptDurations = emptyList(),
+                totalDuration = Duration.ZERO,
+            ),
+        ).right()
+    }
+}
+
+private fun <A> Either<HttpKlientError, A>.rightOrThrow(): A = fold(
+    ifLeft = { error("Forventet Right, fikk $it") },
+    ifRight = { it },
+)

--- a/httpklient/src/test/kotlin/httpklient/HttpKlientTimeoutTest.kt
+++ b/httpklient/src/test/kotlin/httpklient/HttpKlientTimeoutTest.kt
@@ -1,0 +1,107 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTimedValue
+
+/**
+ * Verifiserer at både connect-timeout og per-request timeout fungerer korrekt — både når kallet holder seg innenfor timeouten og når det overskrider den.
+ *
+ * Vi bruker `runBlocking` (ikke `runTest`) fordi vi måler reell veggklokketid: timeouten håndheves av `java.net.http.HttpClient` i ekte tid, og `runTest` ville hoppet over `delay`-basert venting.
+ *
+ * Regresjonsvern: en kjent bug i ktor 3.5.0 gjorde at hvert kall ventet hele timeouten før det returnerte — også når serveren svarte umiddelbart.
+ * Vi vil aldri se den oppførselen her, så de positive testene sjekker eksplisitt at responsen kommer tilbake i *god tid før* timeouten utløper.
+ */
+internal class HttpKlientTimeoutTest {
+
+    @Test
+    fun `rask respons innenfor timeout returnerer raskt og venter ikke til timeout utløper`() {
+        runBlocking {
+            withWireMock { wiremock ->
+                wiremock.stubFor(get(urlEqualTo("/rask")).willReturn(aResponse().withStatus(200).withBody("rask")))
+                val timeout = 5.seconds
+                val klient = testHttpKlient(timeout = timeout)
+                val uri = URI.create("${wiremock.baseUrl()}/rask")
+
+                // Varm opp JVM/HttpClient/wiremock slik at målingen ikke fanger cold-start-kostnad.
+                klient.get<String>(uri).getOrFail()
+
+                val (result, elapsed) = measureTimedValue {
+                    klient.get<String>(uri) { this.timeout = timeout }
+                }
+
+                result.getOrFail().body shouldBe "rask"
+                // Skal komme tilbake langt raskere enn timeouten.
+                // Hvis kallet ventet hele timeouten (slik ktor 3.5.0-bugen gjorde), ville dette vært ~5s.
+                elapsed shouldBeLessThan 1.seconds
+            }
+        }
+    }
+
+    @Test
+    fun `respons som overskrider per-request timeout gir Timeout uten å vente på serveren`() {
+        runBlocking {
+            withWireMock { wiremock ->
+                wiremock.stubFor(
+                    get(urlEqualTo("/treg")).willReturn(aResponse().withStatus(200).withFixedDelay(3_000).withBody("treg")),
+                )
+                val klient = testHttpKlient()
+                val uri = URI.create("${wiremock.baseUrl()}/treg")
+
+                val (result, elapsed) = measureTimedValue {
+                    klient.get<String>(uri) { timeout = 100.milliseconds }
+                }
+
+                result.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.Timeout>()
+                // Timeouten skal fyre rundt 100ms, ikke vente på serverens 3s-delay.
+                elapsed shouldBeLessThan 1.seconds
+            }
+        }
+    }
+
+    @Test
+    fun `tilkobling innenfor connect-timeout lykkes`() {
+        runBlocking {
+            withWireMock { wiremock ->
+                wiremock.stubFor(get(urlEqualTo("/connect-ok")).willReturn(aResponse().withStatus(200).withBody("ok")))
+                // Eksplisitt kort connect-timeout: en localhost-tilkobling skal lykkes godt innenfor.
+                val klient = testHttpKlient(connectTimeout = 1.seconds, timeout = 2.seconds)
+
+                klient.get<String>(URI.create("${wiremock.baseUrl()}/connect-ok")).getOrFail().body shouldBe "ok"
+            }
+        }
+    }
+
+    @Test
+    fun `tilkobling som henger begrenses av connect-timeout, ikke av per-request timeout`() {
+        runBlocking {
+            // 192.0.2.1 er TEST-NET-1 (RFC 5737), reservert for dokumentasjon og rutes normalt ikke.
+            // Et tilkoblingsforsøk dit henger til connect-timeouten fyrer (eventuelt feiler raskt med en nettverksfeil på enkelte oppsett).
+            // Poenget: connect-fasen begrenses av den korte connect-timeouten og henger IKKE til den langt romsligere per-request timeouten.
+            val connectTimeout = 300.milliseconds
+            val requestTimeout = 30.seconds
+            val klient = testHttpKlient(connectTimeout = connectTimeout, timeout = requestTimeout)
+
+            val (result, elapsed) = measureTimedValue {
+                klient.get<String>(URI.create("http://192.0.2.1/henger"))
+            }
+
+            result.isLeft() shouldBe true
+            // Connect-fasen feiler uten en fullstendig respons: enten connect-timeout (Timeout) eller en rask nettverksfeil (NetworkError), avhengig av oppsett.
+            // Begge er IngenRespons; poenget er at vi aldri får en respons og ikke henger til per-request timeouten.
+            result.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.IngenRespons>()
+            // Skal feile lenge før per-request timeouten på 30s — bundet av connect-timeouten.
+            elapsed shouldBeLessThan 10.seconds
+        }
+    }
+}

--- a/httpklient/src/test/kotlin/httpklient/TestSupport.kt
+++ b/httpklient/src/test/kotlin/httpklient/TestSupport.kt
@@ -1,0 +1,110 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import io.github.oshai.kotlinlogging.KLogger
+import io.mockk.mockk
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.libs.httpklient.circuitbreaker.CircuitBreakerConfig
+import no.nav.tiltakspenger.libs.httpklient.retry.RetryConfig
+import java.net.URI
+import java.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
+
+internal data class TestRequestDto(
+    val id: String,
+    val antall: Int,
+)
+
+internal data class TestResponseDto(
+    val status: String,
+    val antall: Int,
+)
+
+internal class SelvRefererendeDto {
+    @Suppress("unused")
+    val self: SelvRefererendeDto = this
+}
+
+/**
+ * Standard test-klient med romslige timeouts som tåler treg CI uten å bli flaky.
+ * Tester som faktisk verifiserer timeout-oppførsel overstyrer alltid timeout eksplisitt (per request eller her).
+ */
+internal fun testHttpKlient(
+    connectTimeout: Duration = 2.seconds,
+    timeout: Duration = 10.seconds,
+    successStatus: (Int) -> Boolean = HttpStatusSuccess.is2xx,
+    loggingConfig: HttpKlientLoggingConfig = HttpKlientLoggingConfig.Disabled,
+    retryConfig: RetryConfig = RetryConfig.None,
+    circuitBreakerConfig: CircuitBreakerConfig = CircuitBreakerConfig.None,
+    clock: Clock = fixedClock,
+): HttpKlient = HttpKlient(clock = clock) {
+    this.connectTimeout = connectTimeout
+    this.defaultTimeout = timeout
+    this.successStatus = successStatus
+    this.logging = loggingConfig
+    this.defaultRetry = retryConfig
+    this.defaultCircuitBreaker = circuitBreakerConfig
+}
+
+/**
+ * Starter en wiremock-server, gir den til [block], og stopper den uansett om [block] feiler.
+ */
+internal suspend fun <T> withWireMock(block: suspend (WireMockServer) -> T): T {
+    val server = WireMockServer(0)
+    server.start()
+    return try {
+        block(server)
+    } finally {
+        server.stop()
+    }
+}
+
+/**
+ * Starter en wiremock-server, henter base-url, stopper serveren igjen og returnerer en URI som peker mot en port der ingen lytter.
+ * Brukes for å teste NetworkError ved "server ikke kontaktbar".
+ */
+internal fun stoppedServerUri(path: String): URI {
+    val server = WireMockServer(0)
+    server.start()
+    val uri = URI.create("${server.baseUrl()}$path")
+    server.stop()
+    return uri
+}
+
+/**
+ * Innkapsler `mockk(relaxed = true)` for KLogger – logging kan ikke testes uten å observere logger, og KLogger har for mange metoder/overloads til at en håndlaget fake er praktisk.
+ */
+internal fun testLogger(): KLogger = mockk(relaxed = true)
+
+/**
+ * Tom [HttpKlientMetadata] for tester der innholdet ikke er relevant (f.eks. validerings-tester av statusCode-grenser).
+ * Vi har ingen defaults i [HttpKlientMetadata] med vilje, så denne fyller ut alle felter eksplisitt med "ikke utført"-verdier.
+ */
+internal fun tomMetadata(
+    rawRequestString: String = "",
+    rawResponseString: String? = null,
+    requestHeaders: Map<String, List<String>> = emptyMap(),
+    responseHeaders: Map<String, List<String>> = emptyMap(),
+    statusCode: Int? = null,
+): HttpKlientMetadata = HttpKlientMetadata(
+    rawRequestString = rawRequestString,
+    rawResponseString = rawResponseString,
+    requestHeaders = requestHeaders,
+    responseHeaders = responseHeaders,
+    statusCode = statusCode,
+    attempts = 0,
+    attemptDurations = emptyList(),
+    totalDuration = ZERO,
+)
+
+internal fun testAccessToken(
+    token: String,
+    clock: Clock = fixedClock,
+): AccessToken = AccessToken(
+    token = token,
+    expiresAt = clock.instant().plusSeconds(60),
+    invaliderCache = {},
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include(
     "persistering:persistering-domene",
     "persistering:persistering-test-common",
     "auth-test-core",
+    "httpklient",
     "json",
     "ktor-common",
     "ktor-test-common",

--- a/test-common/build.gradle.kts
+++ b/test-common/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 
 dependencies {
     api(project(":common"))
+    api(project(":httpklient"))
+    implementation(project(":json"))
 
     api(libs.arrow.core)
 

--- a/test-common/src/main/kotlin/httpklient/HttpKlientFake.kt
+++ b/test-common/src/main/kotlin/httpklient/HttpKlientFake.kt
@@ -1,0 +1,354 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import io.kotest.assertions.fail
+import no.nav.tiltakspenger.libs.json.serialize
+import java.io.IOException
+import java.net.http.HttpTimeoutException
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.time.Duration
+
+/**
+ * Enkel fake for tester i konsumenter av `httpklient`.
+ *
+ * Faken implementerer [HttpKlient], tar opp alle innkommende [HttpKlientRequest] for assertion, og svarer med køede handlers/responser.
+ * Hvis ingen respons er konfigurert returneres en tydelig [HttpKlientError.InvalidRequest] i stedet for å gi en tilfeldig defaultverdi.
+ *
+ * Trådsikker: all tilgang til den interne kø-/request-tilstanden er synkronisert på [lock], slik at faken trygt kan deles mellom coroutines/tråder i parallelle tester (jf. at den virkelige [HttpKlient] også kan brukes parallelt).
+ * Den køede handleren kjøres bevisst _utenfor_ låsen siden den er `suspend`; selve opptaket av requesten og uttaket av handleren skjer atomisk under låsen.
+ */
+class HttpKlientFake : HttpKlient {
+    private val lock = Any()
+    private val queuedResponses = mutableListOf<suspend (HttpKlientRequest) -> Either<HttpKlientError, HttpKlientResponse<Any>>>()
+    private val mutableRequests = mutableListOf<HttpKlientRequest>()
+
+    val requests: List<HttpKlientRequest> get() = synchronized(lock) { mutableRequests.toList() }
+
+    fun reset() {
+        synchronized(lock) {
+            queuedResponses.clear()
+            mutableRequests.clear()
+        }
+    }
+
+    fun enqueueResponse(
+        body: Any,
+        statusCode: Int = 200,
+        responseHeaders: Map<String, List<String>> = emptyMap(),
+        rawResponseString: String? = if (body is Unit) "" else body.toString(),
+        attempts: Int = 1,
+        attemptDurations: List<Duration> = List(attempts) { Duration.ZERO },
+        /** Total veggklokketid inkl. backoff mellom forsøk; null gir summen av attemptDurations. Sett eksplisitt for å modellere retry-backoff. */
+        totalDuration: Duration? = null,
+    ) {
+        krevUtførtForsøk(attempts)
+        require(attemptDurations.size == attempts) {
+            "attemptDurations.size (${attemptDurations.size}) må være lik attempts ($attempts), ellers blir timing-metadata inkonsistent"
+        }
+        krevKonsistentTotalDuration(totalDuration, attemptDurations)
+        enqueue { request ->
+            HttpKlientResponse(
+                statusCode = statusCode,
+                body = body,
+                metadata = metadataFor(
+                    request = request,
+                    rawResponseString = rawResponseString,
+                    responseHeaders = responseHeaders,
+                    statusCode = statusCode,
+                    attempts = attempts,
+                    attemptDurations = attemptDurations,
+                    totalDuration = totalDuration,
+                ),
+            ).right()
+        }
+    }
+
+    fun enqueueUnitResponse(
+        statusCode: Int = 204,
+        responseHeaders: Map<String, List<String>> = emptyMap(),
+    ) {
+        enqueueResponse(
+            body = Unit,
+            statusCode = statusCode,
+            responseHeaders = responseHeaders,
+        )
+    }
+
+    fun enqueueStringResponse(
+        body: String,
+        statusCode: Int = 200,
+        responseHeaders: Map<String, List<String>> = emptyMap(),
+    ) {
+        enqueueResponse(
+            body = body,
+            statusCode = statusCode,
+            responseHeaders = responseHeaders,
+        )
+    }
+
+    fun enqueueError(error: HttpKlientError) {
+        enqueue { error.left() }
+    }
+
+    /**
+     * Køer en [HttpKlientError.Timeout] med korrekt utfylt metadata (effektive headere, redaksjon, timing).
+     * Bruk denne i stedet for [enqueueError] når du vil teste timeout-håndtering uten å bygge metadata selv.
+     */
+    fun enqueueTimeout(
+        throwable: Throwable = HttpTimeoutException("HttpKlientFake simulert timeout"),
+        attempts: Int = 1,
+    ) {
+        krevUtførtForsøk(attempts)
+        enqueue { request ->
+            HttpKlientError.Timeout(
+                throwable = throwable,
+                metadata = metadataFor(request, rawResponseString = null, responseHeaders = emptyMap(), statusCode = null, attempts = attempts),
+            ).left()
+        }
+    }
+
+    /**
+     * Køer en [HttpKlientError.NetworkError] med korrekt utfylt metadata.
+     * Modellerer at requesten aldri nådde fram (DNS, connection refused, tilkobling brutt e.l.).
+     */
+    fun enqueueNetworkError(
+        throwable: Throwable = IOException("HttpKlientFake simulert nettverksfeil"),
+        attempts: Int = 1,
+    ) {
+        krevUtførtForsøk(attempts)
+        enqueue { request ->
+            HttpKlientError.NetworkError(
+                throwable = throwable,
+                metadata = metadataFor(request, rawResponseString = null, responseHeaders = emptyMap(), statusCode = null, attempts = attempts),
+            ).left()
+        }
+    }
+
+    /**
+     * Køer en [HttpKlientError.UventetStatus] med korrekt utfylt metadata.
+     * Modellerer en respons som ble mottatt, men hvis status ikke regnes som vellykket av klienten.
+     */
+    fun enqueueUventetStatus(
+        statusCode: Int,
+        body: String = "",
+        responseHeaders: Map<String, List<String>> = emptyMap(),
+        attempts: Int = 1,
+    ) {
+        krevUtførtForsøk(attempts)
+        enqueue { request ->
+            HttpKlientError.UventetStatus(
+                statusCode = statusCode,
+                body = body,
+                metadata = metadataFor(request, rawResponseString = body, responseHeaders = responseHeaders, statusCode = statusCode, attempts = attempts),
+            ).left()
+        }
+    }
+
+    /**
+     * Køer en [HttpKlientError.DeserializationError] med korrekt utfylt metadata.
+     * Modellerer en respons som ble mottatt med vellykket status, men hvor body-en ikke lot seg tolke til forventet type.
+     */
+    fun enqueueDeserializationError(
+        statusCode: Int = 200,
+        body: String = "",
+        responseHeaders: Map<String, List<String>> = emptyMap(),
+        throwable: Throwable = IllegalStateException("HttpKlientFake simulert deserialiseringsfeil"),
+        attempts: Int = 1,
+    ) {
+        krevUtførtForsøk(attempts)
+        enqueue { request ->
+            HttpKlientError.DeserializationError(
+                throwable = throwable,
+                body = body,
+                statusCode = statusCode,
+                metadata = metadataFor(request, rawResponseString = body, responseHeaders = responseHeaders, statusCode = statusCode, attempts = attempts),
+            ).left()
+        }
+    }
+
+    fun enqueue(
+        response: suspend (HttpKlientRequest) -> Either<HttpKlientError, HttpKlientResponse<Any>>,
+    ) {
+        synchronized(lock) { queuedResponses += response }
+    }
+
+    override suspend fun <Response : Any> request(
+        request: HttpKlientRequest,
+        responseType: KType,
+    ): Either<HttpKlientError, HttpKlientResponse<Response>> {
+        // Opptak av request + uttak av handler skjer atomisk under låsen. Selve handleren kjøres
+        // utenfor låsen siden den er `suspend` (vi kan ikke holde en monitor-lås over en suspensjon).
+        val handler = synchronized(lock) {
+            mutableRequests += request
+            queuedResponses.removeFirstOrNull()
+        }
+
+        val response = handler
+            ?.invoke(request)
+            ?: return noResponseConfigured(request).left()
+
+        // [KType.classifier] er ikke garantert å være en [KClass] (f.eks. type-parametre eller ukjente classifiers).
+        // En usikker cast ville kastet ClassCastException og krasjet faken i stedet for å returnere en kontrollert Either.Left.
+        val responseClass = responseType.classifier as? KClass<*>
+            ?: return invalidResponseType(request, responseType).left()
+
+        return response.flatMap { it.castBody(responseClass) }
+    }
+
+    private fun invalidResponseType(
+        request: HttpKlientRequest,
+        responseType: KType,
+    ): HttpKlientError.InvalidRequest {
+        return HttpKlientError.InvalidRequest(
+            throwable = IllegalArgumentException(
+                "HttpKlientFake støtter kun responstyper med en KClass-classifier, men fikk $responseType",
+            ),
+            metadata = metadataFor(
+                request = request,
+                rawResponseString = null,
+                responseHeaders = emptyMap(),
+                statusCode = null,
+                attempts = 0,
+            ),
+        )
+    }
+
+    private fun noResponseConfigured(request: HttpKlientRequest): HttpKlientError.InvalidRequest {
+        return HttpKlientError.InvalidRequest(
+            throwable = IllegalStateException(
+                "HttpKlientFake mangler konfigurert respons for ${request.method} ${request.uri}",
+            ),
+            metadata = metadataFor(
+                request = request,
+                rawResponseString = null,
+                responseHeaders = emptyMap(),
+                statusCode = null,
+                attempts = 0,
+            ),
+        )
+    }
+
+    private fun <Response : Any> HttpKlientResponse<Any>.castBody(
+        responseType: KClass<*>,
+    ): Either<HttpKlientError, HttpKlientResponse<Response>> {
+        if (!responseType.javaObjectType.isInstance(body)) {
+            return HttpKlientError.DeserializationError(
+                throwable = IllegalStateException(
+                    "HttpKlientFake konfigurert med body av type ${body::class.qualifiedName}, " +
+                        "men requesten forventet ${responseType.qualifiedName}",
+                ),
+                // I produksjon kommer body alltid fra den rå respons-stringen, så vi speiler metadata.rawResponseString (med body.toString() som fallback) for å holde error.body konsistent med metadata.
+                body = metadata.rawResponseString ?: body.toString(),
+                statusCode = statusCode,
+                metadata = metadata,
+            ).left()
+        }
+        @Suppress("UNCHECKED_CAST")
+        return HttpKlientResponse(
+            statusCode = statusCode,
+            body = body as Response,
+            metadata = metadata,
+        ).right()
+    }
+
+    /**
+     * Validerer at en enqueue-helper som modellerer et faktisk utført forsøk (mottatt respons eller forsøk som feilet) har minst ett forsøk.
+     * `attempts = 0` er forbeholdt de interne stiene der requesten aldri ble forsøkt (f.eks. [noResponseConfigured]).
+     */
+    private fun krevUtførtForsøk(attempts: Int) {
+        require(attempts >= 1) { "attempts må være minst 1 for en utført request, var $attempts" }
+    }
+
+    /**
+     * Validerer at en eksplisitt [totalDuration] er minst summen av [attemptDurations].
+     * Speiler produksjon, der totalDuration er forsøkstid pluss ikke-negativ backoff og derfor aldri er mindre enn summen.
+     */
+    private fun krevKonsistentTotalDuration(totalDuration: Duration?, attemptDurations: List<Duration>) {
+        if (totalDuration == null) return
+        val summertForsøkstid = attemptDurations.fold(Duration.ZERO) { sum, duration -> sum + duration }
+        require(totalDuration >= summertForsøkstid) {
+            "totalDuration ($totalDuration) kan ikke være mindre enn summen av attemptDurations ($summertForsøkstid)"
+        }
+    }
+
+    private fun metadataFor(
+        request: HttpKlientRequest,
+        rawResponseString: String?,
+        responseHeaders: Map<String, List<String>>,
+        statusCode: Int?,
+        attempts: Int,
+        attemptDurations: List<Duration> = List(attempts) { Duration.ZERO },
+        /** I produksjon inkluderer totalDuration backoff mellom forsøk og kan overstige summen av attemptDurations; null gir summen som fornuftig standard. */
+        totalDuration: Duration? = null,
+    ): HttpKlientMetadata {
+        val effectiveHeaders = effectiveRequestHeaders(request)
+        val summertForsøkstid = attemptDurations.fold(Duration.ZERO) { sum, duration -> sum + duration }
+        return HttpKlientMetadata(
+            rawRequestString = rawRequestString(request, effectiveHeaders),
+            rawResponseString = rawResponseString,
+            requestHeaders = effectiveHeaders,
+            responseHeaders = responseHeaders,
+            statusCode = statusCode,
+            attempts = attempts,
+            attemptDurations = attemptDurations,
+            totalDuration = totalDuration ?: summertForsøkstid,
+        )
+    }
+
+    /**
+     * Speiler [JavaHttpKlient]: en per-request bearer-token satt via [RequestBuilder.bearerToken]
+     * materialiseres til `Authorization: Bearer <token>` før requesten "sendes", og det er disse
+     * effektive headerne som havner i [HttpKlientMetadata.requestHeaders].
+     * Settes kun hvis `Authorization` ikke allerede er satt (case-insensitivt), akkurat som produksjon.
+     * Holdes med vilje i synk med `InternalHeaders.withBearerToken` (som er `internal` i `httpklient`).
+     */
+    private fun effectiveRequestHeaders(request: HttpKlientRequest): Map<String, List<String>> {
+        val token = request.authToken ?: return request.headers
+        if (request.headers.keys.any { it.equals("Authorization", ignoreCase = true) }) return request.headers
+        return buildMap(request.headers.size + 1) {
+            putAll(request.headers)
+            put("Authorization", listOf("Bearer ${token.token}"))
+        }
+    }
+
+    private fun rawRequestString(
+        request: HttpKlientRequest,
+        effectiveHeaders: Map<String, List<String>>,
+    ): String {
+        return buildString {
+            append(request.method.name)
+            append(" ")
+            append(request.uri)
+            effectiveHeaders.redactSensitiveHeaders().forEach { (name, values) ->
+                values.forEach { value ->
+                    append("\n")
+                    append(name)
+                    append(": ")
+                    append(value)
+                }
+            }
+            request.body?.rawString()?.let { body ->
+                append("\n\n")
+                append(body)
+            }
+        }
+    }
+
+    private fun HttpKlientRequest.Body.rawString(): String = when (this) {
+        // Speiler produksjon: en Json-body serialiseres med samme `serialize` som JavaHttpKlient, ikke `value.toString()`.
+        // `serialize` kan kaste (f.eks. selvrefererende DTO / banlist).
+        // I en fake er det nesten alltid en feil i testoppsettet, så vi feiler testen høylytt med kotest `fail` i stedet for å skjule det bak en placeholder.
+        is HttpKlientRequest.Body.Json -> Either.catch { serialize(value) }.getOrElse { e ->
+            fail("HttpKlientFake klarte ikke å serialisere JSON-body av type ${value::class.qualifiedName}: ${e.message}")
+        }
+
+        is HttpKlientRequest.Body.Raw -> body
+
+        is HttpKlientRequest.Body.RawJson -> body
+    }
+}

--- a/test-common/src/test/kotlin/httpklient/HttpKlientFakeTest.kt
+++ b/test-common/src/test/kotlin/httpklient/HttpKlientFakeTest.kt
@@ -1,0 +1,409 @@
+package no.nav.tiltakspenger.libs.httpklient
+
+import arrow.core.left
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.libs.common.getOrFail
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.time.Instant
+import kotlin.reflect.KClassifier
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class HttpKlientFakeTest {
+    @Test
+    fun `returnerer køet respons og tar opp request`() = runTest {
+        val fake: HttpKlient = HttpKlientFake().apply {
+            enqueueStringResponse("ok")
+        }
+
+        val response = fake.get<String>(URI.create("http://localhost/test")) {
+            header("X-Test", "1")
+        }.getOrFail()
+
+        response.statusCode shouldBe 200
+        response.body shouldBe "ok"
+        response.metadata.rawRequestString shouldContain "GET http://localhost/test"
+        val request = (fake as HttpKlientFake).requests.single()
+        request.method shouldBe HttpMethod.GET
+        request.headers["X-Test"] shouldBe listOf("1")
+    }
+
+    @Test
+    fun `per-request bearerToken materialiseres til effektive headere i metadata og redakteres i rawRequestString`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueStringResponse("ok")
+        }
+        val token = AccessToken(
+            token = "hemmelig-token",
+            expiresAt = Instant.now().plusSeconds(60),
+            invaliderCache = {},
+        )
+
+        val response = fake.get<String>(URI.create("http://localhost/auth")) {
+            bearerToken(token)
+        }.getOrFail()
+
+        // Effektive headere (med Authorization) havner i metadata.requestHeaders med ekte token-verdi, som i produksjon.
+        response.metadata.requestHeaders["Authorization"] shouldBe listOf("Bearer hemmelig-token")
+        // rawRequestString redakterer sensitive headere slik at tokenet ikke lekker.
+        response.metadata.rawRequestString shouldContain "Authorization: ***"
+        response.metadata.rawRequestString shouldNotContain "hemmelig-token"
+    }
+
+    @Test
+    fun `eksplisitt Authorization-header redakteres i rawRequestString`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueStringResponse("ok")
+        }
+
+        val response = fake.get<String>(URI.create("http://localhost/auth")) {
+            header("Authorization", "Bearer manuelt-token")
+            header("Cookie", "session=abc")
+        }.getOrFail()
+
+        response.metadata.requestHeaders["Authorization"] shouldBe listOf("Bearer manuelt-token")
+        response.metadata.rawRequestString shouldContain "Authorization: ***"
+        response.metadata.rawRequestString shouldContain "Cookie: ***"
+        response.metadata.rawRequestString shouldNotContain "manuelt-token"
+        response.metadata.rawRequestString shouldNotContain "session=abc"
+    }
+
+    @Test
+    fun `returnerer tydelig feil hvis ingen respons er konfigurert`() = runTest {
+        val fake = HttpKlientFake()
+
+        val error = fake.get<String>(URI.create("http://localhost/mangler")).swap().getOrNull()!!
+
+        val invalidRequest = error.shouldBeInstanceOf<HttpKlientError.InvalidRequest>()
+        invalidRequest.throwable.message shouldBe
+            "HttpKlientFake mangler konfigurert respons for GET http://localhost/mangler"
+        invalidRequest.metadata.attempts shouldBe 0
+    }
+
+    @Test
+    fun `type mismatch blir DeserializationError`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueResponse(123)
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/feil-type")).swap().getOrNull()!!
+
+        val deserializationError = error.shouldBeInstanceOf<HttpKlientError.DeserializationError>()
+        deserializationError.statusCode shouldBe 200
+        deserializationError.body shouldBe "123"
+    }
+
+    @Test
+    fun `DeserializationError ved type-mismatch bruker rawResponseString-override slik at body er konsistent med metadata`() = runTest {
+        // I produksjon kommer DeserializationError.body alltid fra den rå respons-stringen, så faken må bruke metadata.rawResponseString (ikke body.toString()) når testen overstyrer rå respons.
+        val fake = HttpKlientFake().apply {
+            enqueueResponse(body = 123, rawResponseString = "raw-fra-server")
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/raw-mismatch")).swap().getOrNull()!!
+
+        val deserializationError = error.shouldBeInstanceOf<HttpKlientError.DeserializationError>()
+        deserializationError.body shouldBe "raw-fra-server"
+        deserializationError.body shouldBe deserializationError.metadata.rawResponseString
+    }
+
+    @Test
+    fun `kan køe custom handler og error`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueue { request ->
+                HttpKlientError.NetworkError(
+                    throwable = RuntimeException("nede"),
+                    metadata = HttpKlientMetadata(
+                        rawRequestString = "${request.method} ${request.uri}",
+                        rawResponseString = null,
+                        requestHeaders = request.headers,
+                        responseHeaders = emptyMap(),
+                        statusCode = null,
+                        attempts = 1,
+                        attemptDurations = emptyList(),
+                        totalDuration = kotlin.time.Duration.ZERO,
+                    ),
+                ).left()
+            }
+            enqueueUnitResponse()
+        }
+
+        fake.get<String>(URI.create("http://localhost/1")).swap().getOrNull()!!
+            .shouldBeInstanceOf<HttpKlientError.NetworkError>()
+        fake.post<Unit>(URI.create("http://localhost/2")).getOrFail().statusCode shouldBe 204
+
+        fake.requests shouldHaveSize 2
+        fake.requests[0].method shouldBe HttpMethod.GET
+        fake.requests[1].method shouldBe HttpMethod.POST
+    }
+
+    @Test
+    fun `Unit-respons gir tom rawResponseString i metadata`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueUnitResponse()
+        }
+
+        val response = fake.post<Unit>(URI.create("http://localhost/unit")).getOrFail()
+
+        response.statusCode shouldBe 204
+        response.metadata.rawResponseString shouldBe ""
+    }
+
+    @Test
+    fun `rawResponseString kan overstyres eksplisitt`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueResponse(body = "domeneobjekt", rawResponseString = "{\"raw\":true}")
+        }
+
+        val response = fake.get<String>(URI.create("http://localhost/raw")).getOrFail()
+
+        response.body shouldBe "domeneobjekt"
+        response.metadata.rawResponseString shouldBe "{\"raw\":true}"
+    }
+
+    @Test
+    fun `attempts og attemptDurations kan konfigureres og totalDuration summeres`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueResponse(
+                body = "ok",
+                attempts = 3,
+                attemptDurations = listOf(10.milliseconds, 20.milliseconds, 30.milliseconds),
+            )
+        }
+
+        val metadata = fake.get<String>(URI.create("http://localhost/retry")).getOrFail().metadata
+
+        metadata.attempts shouldBe 3
+        metadata.attemptDurations shouldBe listOf(10.milliseconds, 20.milliseconds, 30.milliseconds)
+        metadata.totalDuration shouldBe 60.milliseconds
+    }
+
+    @Test
+    fun `totalDuration kan settes uavhengig av attemptDurations for å modellere retry-backoff`() = runTest {
+        // I produksjon inkluderer totalDuration backoff mellom forsøk, så den kan overstige summen av attemptDurations.
+        // Faken må la testen modellere denne forskjellen, ikke alltid bruke summen.
+        val fake = HttpKlientFake().apply {
+            enqueueResponse(
+                body = "ok",
+                attempts = 2,
+                attemptDurations = listOf(10.milliseconds, 20.milliseconds),
+                totalDuration = 100.milliseconds,
+            )
+        }
+
+        val metadata = fake.get<String>(URI.create("http://localhost/backoff")).getOrFail().metadata
+
+        metadata.attemptDurations shouldBe listOf(10.milliseconds, 20.milliseconds)
+        metadata.totalDuration shouldBe 100.milliseconds
+    }
+
+    @Test
+    fun `enqueueResponse avviser attempts under 1`() {
+        shouldThrowWithMessage<IllegalArgumentException>("attempts må være minst 1 for en utført request, var 0") {
+            HttpKlientFake().enqueueResponse(body = "ok", attempts = 0)
+        }
+    }
+
+    @Test
+    fun `enqueueResponse avviser inkonsistent attemptDurations`() {
+        shouldThrowWithMessage<IllegalArgumentException>(
+            "attemptDurations.size (2) må være lik attempts (3), ellers blir timing-metadata inkonsistent",
+        ) {
+            HttpKlientFake().enqueueResponse(
+                body = "ok",
+                attempts = 3,
+                attemptDurations = listOf(10.milliseconds, 20.milliseconds),
+            )
+        }
+    }
+
+    @Test
+    fun `error-helpers avviser attempts under 1`() {
+        shouldThrowWithMessage<IllegalArgumentException>("attempts må være minst 1 for en utført request, var 0") {
+            HttpKlientFake().enqueueTimeout(attempts = 0)
+        }
+    }
+
+    @Test
+    fun `enqueueTimeout gir Timeout med utfylt metadata`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueTimeout()
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/timeout")).swap().getOrNull()!!
+
+        val timeout = error.shouldBeInstanceOf<HttpKlientError.Timeout>()
+        timeout.metadata.attempts shouldBe 1
+        timeout.metadata.rawRequestString shouldContain "GET http://localhost/timeout"
+    }
+
+    @Test
+    fun `enqueueNetworkError gir NetworkError med utfylt metadata`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueNetworkError()
+        }
+
+        fake.get<String>(URI.create("http://localhost/nede")).swap().getOrNull()!!
+            .shouldBeInstanceOf<HttpKlientError.NetworkError>()
+    }
+
+    @Test
+    fun `enqueueUventetStatus gir UventetStatus med status og body i metadata`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueUventetStatus(statusCode = 503, body = "Service Unavailable")
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/503")).swap().getOrNull()!!
+
+        val uventetStatus = error.shouldBeInstanceOf<HttpKlientError.UventetStatus>()
+        uventetStatus.statusCode shouldBe 503
+        uventetStatus.body shouldBe "Service Unavailable"
+        uventetStatus.metadata.statusCode shouldBe 503
+        uventetStatus.metadata.rawResponseString shouldBe "Service Unavailable"
+    }
+
+    @Test
+    fun `enqueueDeserializationError gir DeserializationError med status og body`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueDeserializationError(statusCode = 200, body = "ikke-gyldig-json")
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/deser")).swap().getOrNull()!!
+
+        val deserializationError = error.shouldBeInstanceOf<HttpKlientError.DeserializationError>()
+        deserializationError.statusCode shouldBe 200
+        deserializationError.body shouldBe "ikke-gyldig-json"
+    }
+
+    @Test
+    fun `error-helpers redakterer sensitive headere i metadata`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueUventetStatus(statusCode = 500)
+        }
+
+        val error = fake.get<String>(URI.create("http://localhost/redaksjon")) {
+            header("Authorization", "Bearer hemmelig")
+        }.swap().getOrNull()!!
+
+        error.metadata.requestHeaders["Authorization"] shouldBe listOf("Bearer hemmelig")
+        error.metadata.rawRequestString shouldContain "Authorization: ***"
+        error.metadata.rawRequestString shouldNotContain "hemmelig"
+    }
+
+    @Test
+    fun `responstype uten KClass-classifier gir kontrollert InvalidRequest i stedet for å kaste`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueStringResponse("fanget")
+            enqueueStringResponse("med-ugyldig-type")
+        }
+
+        // Fang en ekte materialisert request fra et vanlig kall, slik at vi kan gjenbruke den i et direkte request()-kall.
+        fake.get<String>(URI.create("http://localhost/fang")).getOrFail()
+        val capturedRequest = fake.requests.single()
+
+        // En KType uten KClass-classifier (her: classifier = null) trigger den usikre cast-grenen uten å dra inn kotlin-reflect.
+        val typeUtenKClass = object : KType {
+            override val classifier: KClassifier? = null
+            override val arguments: List<KTypeProjection> = emptyList()
+            override val isMarkedNullable: Boolean = false
+            override val annotations: List<Annotation> = emptyList()
+        }
+
+        val result = fake.request<Any>(capturedRequest, typeUtenKClass)
+
+        result.swap().getOrNull()!!.shouldBeInstanceOf<HttpKlientError.InvalidRequest>()
+    }
+
+    @Test
+    fun `json-body serialiseres som i produksjon i rawRequestString`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueUnitResponse()
+        }
+
+        val response = fake.post<Unit>(URI.create("http://localhost/json")) {
+            json(JsonBodyDto(id = "abc", antall = 2))
+        }.getOrFail()
+
+        // Speiler JavaHttpKlient: faktisk JSON, ikke data class-ens toString().
+        response.metadata.rawRequestString shouldContain "\"id\":\"abc\""
+        response.metadata.rawRequestString shouldContain "\"antall\":2"
+        response.metadata.rawRequestString shouldNotContain "JsonBodyDto("
+    }
+
+    private data class JsonBodyDto(val id: String, val antall: Int)
+
+    @Test
+    fun `json-body som ikke lar seg serialisere feiler testen med tydelig melding`() = runTest {
+        // En body som ikke lar seg serialisere (her: selvrefererende DTO -> uendelig rekursjon) er nesten alltid en feil i testoppsettet.
+        // Faken skal da feile testen høylytt med en tydelig melding, ikke skjule det.
+        val fake = HttpKlientFake().apply {
+            enqueueUnitResponse()
+        }
+
+        val thrown = shouldThrow<AssertionError> {
+            fake.post<Unit>(URI.create("http://localhost/json-feil")) {
+                json(SelvRefererendeJsonDto())
+            }
+        }
+
+        thrown.message shouldContain "HttpKlientFake klarte ikke å serialisere JSON-body"
+        thrown.message shouldContain SelvRefererendeJsonDto::class.qualifiedName!!
+    }
+
+    private class SelvRefererendeJsonDto {
+        @Suppress("unused")
+        val self: SelvRefererendeJsonDto = this
+    }
+
+    @Test
+    fun `reset sletter requests og køede responser`() = runTest {
+        val fake = HttpKlientFake().apply {
+            enqueueStringResponse("ok")
+        }
+        fake.get<String>(URI.create("http://localhost/for-reset")).getOrFail()
+
+        fake.reset()
+
+        fake.requests shouldHaveSize 0
+        fake.get<String>(URI.create("http://localhost/etter-reset")).swap().getOrNull()!!
+            .shouldBeInstanceOf<HttpKlientError.InvalidRequest>()
+    }
+
+    @Test
+    fun `kan brukes fra mange coroutines parallelt uten å miste requests eller responser`() {
+        // Bruker runBlocking + Dispatchers.IO for ekte parallellitet på flere tråder, slik at
+        // synkroniseringen i HttpKlientFake faktisk blir utfordret (runTest kjører enkelt-trådet).
+        runBlocking {
+            val antall = 200
+            val fake = HttpKlientFake()
+            repeat(antall) { fake.enqueueStringResponse("ok-$it") }
+
+            val resultater = withContext(Dispatchers.IO) {
+                (0 until antall).map { i ->
+                    async {
+                        fake.get<String>(URI.create("http://localhost/parallell/$i")).getOrFail().body
+                    }
+                }.awaitAll()
+            }
+
+            // Hver kø-respons skal være konsumert nøyaktig én gang (ingen tapt/duplisert under race).
+            resultater.toSet() shouldBe (0 until antall).map { "ok-$it" }.toSet()
+            fake.requests shouldHaveSize antall
+        }
+    }
+}


### PR DESCRIPTION
Tanken er at alle repoene bruker denne istedenfor nåværende. Flytt mest mulig felles og boilerplate hit. Utvid og gjør mer fleksibel ved behov/mangler